### PR TITLE
show_pydoc chokes when more than one python syntax file exists

### DIFF
--- a/plugin/jedi.vim
+++ b/plugin/jedi.vim
@@ -141,8 +141,7 @@ PYTHONEOF
 
     " highlight python code within rst
     unlet! b:current_syntax
-    let l:pythonpath = fnameescape(globpath(&rtp,"syntax/python.vim"))
-    exe "syn include @rstPythonScript ".l:pythonpath
+    syn include @rstPythonScript syntax/python.vim
     " 4 spaces
     syn region rstPythonRegion start=/^\v {4}/ end=/\v^( {4}|\n)@!/ contains=@rstPythonScript
     " >>> python code


### PR DESCRIPTION
globpath returns a concatenation of all files, separated by newline. This makes :syn include throw an error. But as :syn include automatically searches 'runtimepath' and loads all files it finds, globbing is unnecessary.
