### PR TITLE
os.P_NOWAIT completion

### DIFF
--- a/test/regression.py
+++ b/test/regression.py
@@ -197,6 +197,10 @@ class TestRegression(Base):
         assert len(api.Script(s, 1, 15, '/').get_definition()) == 1
         assert len(api.Script(s, 1, 10, '/').get_definition()) == 1
 
+    def test_os_nowait(self):
+        s = self.complete("import os; os.P_")
+        assert 'P_NOWAIT' in [i.word for i in s]
+
 
 class TestSpeed(Base):
     def _check_speed(time_per_run, number=10):


### PR DESCRIPTION
When completing `os.P_`, the only results are `P_WAIT` and `P_NOWAITO`. `P_NOWAIT` should be included too. See http://docs.python.org/library/os.html#os.P_NOWAIT for reference.

The code in `os.py` looks like this:

```
520 if _exists("fork") and not _exists("spawnv") and _exists("execv"):                                  
521                                                                                                     
522     P_WAIT = 0                                                                                      
523     P_NOWAIT = P_NOWAITO = 1                                                                                          
```

I added a regression test for this, maybe you can use it.
