### PR TITLE
Ignore IOError when checking Python file

### DIFF
--- a/jedi/dynamic.py
+++ b/jedi/dynamic.py
@@ -33,7 +33,10 @@ def get_directory_modules_for_name(mods, name):
         try:
             return builtin.CachedModule.cache[path][1].module
         except KeyError:
-            return check_fs(path)
+            try:
+                return check_fs(path)
+            except IOError:
+                return None
 
     def check_fs(path):
         with open(path) as f:


### PR DESCRIPTION
Emacs uses a symbolic link to non-existing file for locking file.
It has the same extension as the original file.  Therefore, Jedi
must ignore IOError when trying to open this symbolic file.

I think it makes sense for non-Emacs users.  The file you
are trying to open may not exist at the timing when you open
it.  Also, people can make bad symbolic links accidentally.
Jedi should work even in this situation.
