### PR TITLE
Crashes on pypy

### DIFF
--- a/jedi/builtin.py
+++ b/jedi/builtin.py
@@ -302,6 +302,8 @@ def _generate_code(scope, mixin_funcs={}, depth=0):
                 mixin = mixin_funcs[name]
             except KeyError:
                 mixin = {}
+            if not isinstance(mixin, dict):
+                mixin = {}
             cl_code = _generate_code(cl, mixin, depth + 1)
             code += parsing.indent_block(cl_code)
         code += '\n'
@@ -314,6 +316,9 @@ def _generate_code(scope, mixin_funcs={}, depth=0):
         doc_str = get_doc(func, indent=True)
         try:
             mixin = mixin_funcs[name]
+            # In pypy reversed is builtin
+            if isinstance(mixin, dict):
+                raise KeyError()
         except KeyError:
             # normal code generation
             code += 'def %s(%s):\n' % (name, params)

--- a/jedi/helpers.py
+++ b/jedi/helpers.py
@@ -105,8 +105,9 @@ class ExecutionRecursionDecorator(object):
 
     @classmethod
     def cleanup(cls):
-        cls.parent_execution_funcs.pop()
-        cls.recursion_level -= 1
+        if cls.parent_execution_funcs:
+            cls.parent_execution_funcs.pop()
+            cls.recursion_level -= 1
 
     @classmethod
     def check_recursion(cls, execution, evaluate_generator):


### PR DESCRIPTION
There are some problems with pypy implementation which leads to errors like this:

```
  File "/home/zero/.envs/pypywdb/site-packages/jedi/api.py", line 120, in complete
    for scope, name_list in scope_generator:
  File "/home/zero/.envs/pypywdb/site-packages/jedi/evaluate.py", line 1016, in get_names_for_scope
    builtin_scope = builtin.Builtin.scope
  File "/home/zero/.envs/pypywdb/site-packages/jedi/builtin.py", line 452, in scope
    return self.builtin.parser.module
  File "/home/zero/.envs/pypywdb/site-packages/jedi/builtin.py", line 61, in parser
    self._load_module()
  File "/home/zero/.envs/pypywdb/site-packages/jedi/builtin.py", line 68, in _load_module
    source = self._get_source()
  File "/home/zero/.envs/pypywdb/site-packages/jedi/builtin.py", line 160, in _get_source
    return _generate_code(self.module, self._load_mixins())
  File "/home/zero/.envs/pypywdb/site-packages/jedi/builtin.py", line 327, in _generate_code
    pos = re.search(r'\):\s*\n', mixin).end()
  File "/opt/pypy/lib-python/2.7/re.py", line 142, in search
    return _compile(pattern, flags).search(string)
TypeError: unsupported operand type for unary buffer: 'dict'
```

After some investigation, it appears that `reversed` is a class in CPython but a builtin in pypy which leads to a fatal `re.search` on a dict.

This patch doesn't fix the problem but just avoid crashes on completion.
I made this workaround because jedi works good enough without that on pypy as I use it on my web debugger [wdb](https://github.com/Kozea/wdb) which works with pypy. 
