### PR TITLE
Added quick_complete convenience function

### DIFF
--- a/jedi/__init__.py
+++ b/jedi/__init__.py
@@ -29,7 +29,7 @@ import sys
 # imports and circular imports... Just avoid it:
 sys.path.insert(0, __path__[0])
 
-from .api import Script, NotFoundError, quick_complete, set_debug_function
+from .api import Script, NotFoundError, set_debug_function, _quick_complete
 from . import settings
 
 from . import api

--- a/jedi/api.py
+++ b/jedi/api.py
@@ -7,7 +7,7 @@ catch :exc:`NotFoundError` which is being raised if your completion is not
 possible.
 """
 from __future__ import with_statement
-__all__ = ['Script', 'NotFoundError', 'quick_complete', 'set_debug_function']
+__all__ = ['Script', 'NotFoundError', 'set_debug_function', '_quick_complete']
 
 import re
 
@@ -454,26 +454,6 @@ class Script(object):
         api_classes._clear_caches()
 
 
-def quick_complete(source):
-    """
-    Convenience function to complete a source string at the end.
-
-    Example::
-
-        >>> quick_complete('import json\\njson.l')
-        [<Completion: load>, <Completion: loads>]
-
-    :param source: The source code to be completed.
-    :type source: string
-    :return: Completion objects as returned by :meth:`complete`.
-    :rtype: list of :class:`api_classes.Completion`
-    """
-    lines = re.sub(r'[\n\r\s]*$', '', source).splitlines()
-    pos = len(lines), len(lines[-1])
-    script = Script(source, pos[0], pos[1], '')
-    return script.complete()
-
-
 def set_debug_function(func_cb=debug.print_to_stdout, warnings=True,
                                             notices=True, speed=True):
     """
@@ -485,3 +465,23 @@ def set_debug_function(func_cb=debug.print_to_stdout, warnings=True,
     debug.enable_warning = warnings
     debug.enable_notice = notices
     debug.enable_speed = speed
+
+
+def _quick_complete(source):
+    """
+    Convenience function to complete a source string at the end.
+
+    Example::
+
+        >>> _quick_complete('import json\\njson.l')
+        [<Completion: load>, <Completion: loads>]
+
+    :param source: The source code to be completed.
+    :type source: string
+    :return: Completion objects as returned by :meth:`complete`.
+    :rtype: list of :class:`api_classes.Completion`
+    """
+    lines = re.sub(r'[\n\r\s]*$', '', source).splitlines()
+    pos = len(lines), len(lines[-1])
+    script = Script(source, pos[0], pos[1], '')
+    return script.complete()

--- a/test/regression.py
+++ b/test/regression.py
@@ -348,7 +348,7 @@ class TestFeature(Base):
         ]
         for source, pos in sources:
             # Run quick_complete
-            quick_completions = api.quick_complete(source)
+            quick_completions = api._quick_complete(source)
             # Run real completion
             script = api.Script(source, pos[0], pos[1], '')
             real_completions = script.complete()


### PR DESCRIPTION
I'd like to have a `quick_complete(source)` convenience function shipped with jedi. The purpose is to complete a source string at its end.

Reasons:

```
>>> import jedi
>>> source = '''import json; json.l'''
>>> script = jedi.Script(source, 1, 19, '')
>>> completions = script.complete()
```

vs

```
>>> import jedi
>>> source = '''import json; json.l'''
>>> completions = jedi.quick_complete(source)
```

The main use is surely testing and debugging. It's very easy to quickly see the completions for a specific test string.

I'm pretty sure there are also use cases outside of dev and debugging. If there are, then the function should be in `api.py` (-> `jedi.quick_complete`). Otherwise, I'd suggest either `api._quick_complete` or `utils.quick_complete`.

Opinions?
