### PR TITLE
Basic Python 3.3 compatibility

### DIFF
--- a/jedi/_compatibility.py
+++ b/jedi/_compatibility.py
@@ -5,6 +5,7 @@ python versions.
 import sys
 
 is_py3k = sys.hexversion >= 0x03000000
+is_py33 = sys.hexversion >= 0x03030000
 
 is_py25 = sys.hexversion < 0x02060000
 


### PR DESCRIPTION
In python 3.3 the implementation of the import system is rewritten from scratch and based on importlib. Also some new functionality was introduced, such as namespace packages (directories in pythonpath without **init**.py files)

This fix restores most of failing unittests under 3.3, and adds basic support for namespace packages.

This commit is very WIP, and maybe considered as a proof of concept.
