### PR TITLE
Set XDG_CACHE_HOME in tox to avoid contaminating ~/.cache

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,8 @@
 [tox]
 envlist = py25, py26, py27, py32
 [testenv]
+setenv =
+    XDG_CACHE_HOME={envtmpdir}/cache
 commands =
     python regression.py
     python run.py


### PR DESCRIPTION
I guess this is the easiest fix.  If you were using unittest (or nose or py.test), proper fix is as easy as using `setUp`/`tearDown`, though.
