### PR TITLE
Add inheritance-diagram to Sphinx documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,7 +27,8 @@ sys.path.append(os.path.abspath('_themes'))
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.viewcode', 'sphinx.ext.todo']
+extensions = ['sphinx.ext.autodoc', 'sphinx.ext.viewcode', 'sphinx.ext.todo',
+              'sphinx.ext.inheritance_diagram']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/docs/development.rst
+++ b/docs/docs/development.rst
@@ -61,6 +61,22 @@ Parser Representation (parser_representation.py)
 
 .. automodule:: parsing_representation
 
+.. inheritance-diagram::
+   SubModule
+   Class
+   Function
+   Lambda
+   Flow
+   ForFlow
+   Import
+   Statement
+   Param
+   Call
+   Array
+   Name
+   ListComprehension
+   :parts: 1
+
 .. _evaluate:
 
 Evaluation of python code (evaluate.py)
@@ -73,6 +89,16 @@ Evaluation Representation (evaluate_representation.py)
 
 .. automodule:: evaluate_representation
 
+.. inheritance-diagram::
+   Executable
+   Instance
+   InstanceElement
+   Class
+   Function
+   Execution
+   Generator
+   Array
+   :parts: 1
 
 .. _dev-api:
 


### PR DESCRIPTION
Like this:

![inheritance-298b2ffbd7b15206a419cc17082e3b0da9c1c287](https://f.cloud.github.com/assets/29282/189983/f7fdd76a-7ebf-11e2-8f71-d3d877af6a20.png)

You need graphiz to build the doc.  Readthedocs support it.
