### PR TITLE
Make VIRTUAL_ENV actually importable

### DIFF
--- a/jedi/modules.py
+++ b/jedi/modules.py
@@ -279,9 +279,8 @@ def get_sys_path():
             venv, 'lib', 'python%d.%d' % sys.version_info[:2], 'site-packages')
         sys_path.insert(0, p)
 
-    p = sys.path[1:]
-    check_virtual_env(p)
-    return p
+    check_virtual_env(sys.path)
+    return [p for p in sys.path if p != ""]
 
 
 @cache.memoize_default([])


### PR DESCRIPTION
I had this strange error when I run `py.test` instead of `tox`:

```
name = 'site-packages.numpy.core.umath'
path = '/home/takafumi/.virtualenvs/mypy/lib/python2.7'

    def load_module(name, path):
        if path:
            self.sys_path.insert(0, path)

        temp, sys.path = sys.path, self.sys_path
        content = {}
        try:
>           exec_function('import %s as module' % name, content)

jedi/builtin.py:90: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

source = 'import site-packages.numpy.core.umath as module'
global_map = {'__builtins__': {'ArithmeticError': <type 'exceptions.ArithmeticError'>, 'AssertionError': <type 'exceptions.AssertionError'>, 'AttributeError': <type 'exceptions.AttributeError'>, 'BaseException': <type 'exceptions.BaseException'>, ...}}

>   ???
E     File "<string>", line 1
E       import site-packages.numpy.core.umath as module
E                  ^
E   SyntaxError: invalid syntax

blub:2: SyntaxError
================= 1 failed, 40 passed, 1 skipped in 6.88 seconds =================
py.test test/test_regression.py  7.26s user 0.18s system 95% cpu 7.802 total
```

It turned out that this is because `sys.path` is used in `BuiltinModule.module` when searching for module.  As we are using real import machinery for builtin module, I think we should just add it to `sys.path` rather than Jedi's internal copy.
