### PR TITLE
Automatically skip thirdparty test if not importable

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -56,7 +56,7 @@ def pytest_generate_tests(metafunc):
         cases = list(run.collect_dir_tests(base_dir, test_files))
         if thirdparty:
             cases.extend(run.collect_dir_tests(
-                os.path.join(base_dir, 'thirdparty'), test_files))
+                os.path.join(base_dir, 'thirdparty'), test_files, True))
         metafunc.parametrize('case', cases)
     if 'refactor_case' in metafunc.fixturenames:
         base_dir = metafunc.config.option.refactor_case_dir

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -1,6 +1,8 @@
 import os
 import re
 
+import pytest
+
 from . import base
 from .run import \
     TEST_COMPLETIONS, TEST_DEFINITIONS, TEST_ASSIGNMENTS, TEST_USAGES
@@ -97,6 +99,8 @@ def run_related_name_test(case):
 
 
 def test_integration(case, monkeypatch, pytestconfig):
+    if case.skip is not None:
+        pytest.skip(case.skip)
     repo_root = base.root_dir
     monkeypatch.chdir(os.path.join(repo_root, 'jedi'))
     testers = {


### PR DESCRIPTION
I forgot to migrate this feature.
