### PR TITLE
Fix ImportError when building Sphinx

### DIFF
--- a/docs/docs/testing.rst
+++ b/docs/docs/testing.rst
@@ -14,10 +14,10 @@ Blackbox Tests (run.py)
 
 .. automodule:: test.run
 
-Regression Tests (regression.py)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Regression Tests (test_regression.py)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. automodule:: test.regression
+.. automodule:: test.test_regression
 
 Refactoring Tests (refactor.py)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
I forgot to rename the module in the document.
