### PR TITLE
Document api_classes

### DIFF
--- a/jedi/api_classes.py
+++ b/jedi/api_classes.py
@@ -151,7 +151,7 @@ class BaseDefinition(object):
         """
         path = self.module_path
         sep = os.path.sep
-        p = re.sub(r'^.*?([\w\d]+)(%s__init__)?.py$' % sep, r'\1', path)
+        p = re.sub(r'^.*?([\w\d]+)(%s__init__)?.(py|so)$' % sep, r'\1', path)
         return p
 
     def in_builtin_module(self):


### PR DESCRIPTION
I don't know why `BaseDefinition.path` is exposed as a public attribute so I didn't document it.  Probably you should rename it to `_path` or something.
