### PR TITLE
Hide api_classes.defined_names in document

### DIFF
--- a/jedi/api.py
+++ b/jedi/api.py
@@ -507,7 +507,7 @@ def defined_names(source, source_path=None, source_encoding='utf-8'):
         modules.source_to_unicode(source, source_encoding),
         module_path=source_path,
     )
-    return api_classes.defined_names(parser.scope)
+    return api_classes._defined_names(parser.scope)
 
 
 def set_debug_function(func_cb=debug.print_to_stdout, warnings=True,

--- a/jedi/api_classes.py
+++ b/jedi/api_classes.py
@@ -365,10 +365,10 @@ class Definition(BaseDefinition):
             d = d.var
         if isinstance(d, pr.Name):
             d = d.parent
-        return defined_names(d)
+        return _defined_names(d)
 
 
-def defined_names(scope):
+def _defined_names(scope):
     """
     List sub-definitions (e.g., methods in class).
 


### PR DESCRIPTION
It is in the document: http://jedi.jedidjah.ch/en/dev/docs/plugin-api.html#api_classes.defined_names

But it shouldn't, as it is just a helper function.
