### PR TITLE
Configuration to run coveralls on py33

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,11 @@
 *~
 *.swp
 *.swo
+*.pyc
 .ropeproject
 .tox
-*.pyc
+.coveralls.yml
+.coverage
 /build/
 /docs/_build/
 /dist/

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ env:
     - TOXENV=py32
     - TOXENV=py33
 install:
-    - pip install --quiet --use-mirrors tox
+    - pip install --quiet --use-mirrors tox coveralls
 script:
     - tox
+    - if [ $TOXENV == "py33" ]; then coveralls; fi

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist = py25, py26, py27, py32, py33
 deps =
     pytest
 commands =
-    py.test []
+    py.test jedi
 [testenv:py25]
 deps =
     simplejson
@@ -14,3 +14,8 @@ deps =
 deps =
     unittest2
     {[testenv]deps}
+[testenv:py33]
+deps =
+    pytest-cov
+commands =
+    py.test --cov jedi


### PR DESCRIPTION
I setup tox and travis to run pytest-coverage and coveralls on Python 3.3 (no need to run on multiple versions).

Some tests fail, as discussed in #196 (see https://travis-ci.org/davidhalter/jedi/jobs/6219527). I don't know Jedi and pytest enough to be able to debug this issue. Maybe @tkf can help?

As soon as the tests work, we can merge it into dev. Sample coverage report: https://coveralls.io/builds/16192

Blocking issues:
- [x] Failing tests
- [ ] Somehow imports and function/class declarations [aren't counted](https://coveralls.io/builds/16192/source?filename=jedi%2Fevaluate_representation.py) in coverage report
