### PR TITLE
Fixed py.test coverage.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,9 @@
 [run]
 omit =
+    jedi/__init__.py
     jedi/_compatibility.py
+    jedi/errors.py
+    jedi/settings.py
 
 [report]
 # Regexes for lines to exclude from consideration

--- a/jedi/__init__.py
+++ b/jedi/__init__.py
@@ -36,13 +36,21 @@ good text editor, while still having very good IDE features for Python.
 
 __version__ = 0, 6, 0
 
-import sys
+from functools import partial
 
-# python imports are hell sometimes. Especially the combination of relative
-# imports and circular imports... Just avoid it:
-sys.path.insert(0, __path__[0])
-
-from .api import Script, NotFoundError, set_debug_function, _quick_complete
 from . import settings
+from .errors import NotFoundError
 
-sys.path.pop(0)
+
+def lazy_import_api_call(fname, *args, **kwargs):
+    from . import api
+    for name in ['Script', 'set_debug_function', '_quick_complete']:
+        globals()[name] = getattr(api, name)
+    return globals()[fname](*args, **kwargs)
+
+# These names are imported lazy and replaced later by jedi.api objects.
+# If the __doc__ string is important, any of these objects should be used
+# first or jedi.api should be imported.
+Script = partial(lazy_import_api_call, 'Script')
+set_debug_function = partial(lazy_import_api_call, 'set_debug_function')
+_quick_complete = partial(lazy_import_api_call, '_quick_complete')

--- a/jedi/api.py
+++ b/jedi/api.py
@@ -21,6 +21,8 @@ from jedi import common
 from jedi import cache
 from jedi import modules
 from jedi._compatibility import next, unicode
+from jedi import lazy_import_api_call
+from jedi.errors import NotFoundError
 import evaluate
 import keywords
 import api_classes
@@ -28,11 +30,6 @@ import evaluate_representation as er
 import dynamic
 import imports
 import builtin
-
-
-class NotFoundError(Exception):
-    """A custom error to avoid catching the wrong exceptions."""
-    pass
 
 
 class Script(object):
@@ -555,3 +552,6 @@ def _quick_complete(source):
     pos = len(lines), len(lines[-1])
     script = Script(source, pos[0], pos[1], '')
     return script.completions()
+
+# it replaces __doc__ strings for all lazy imported objects, otherwise not important
+lazy_import_api_call('NotFoundError')

--- a/jedi/errors.py
+++ b/jedi/errors.py
@@ -1,0 +1,3 @@
+class NotFoundError(Exception):
+    """A custom error to avoid catching the wrong exceptions."""
+    pass

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,0 +1,4 @@
+from os.path import abspath, dirname
+
+test_dir = dirname(abspath(__file__))
+root_dir = dirname(test_dir)

--- a/test/base.py
+++ b/test/base.py
@@ -4,14 +4,11 @@ if sys.hexversion < 0x02070000:
 else:
     import unittest
 import os
-from os.path import abspath, dirname
+from os.path import dirname
 import functools
 
+from . import root_dir, test_dir
 import jedi
-
-
-test_dir = dirname(abspath(__file__))
-root_dir = dirname(test_dir)
 
 
 sample_int = 1  # This is used in completion/imports.py

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -4,19 +4,17 @@ import tempfile
 
 import pytest
 
-from . import base
-from . import run
-from . import refactor
-
+from . import test_dir
+from jedi import settings
 
 def pytest_addoption(parser):
     parser.addoption(
         "--integration-case-dir",
-        default=os.path.join(base.test_dir, 'completion'),
+        default=os.path.join(test_dir, 'completion'),
         help="Directory in which integration test case files locate.")
     parser.addoption(
         "--refactor-case-dir",
-        default=os.path.join(base.test_dir, 'refactor'),
+        default=os.path.join(test_dir, 'refactor'),
         help="Directory in which refactoring test case files locate.")
     parser.addoption(
         "--test-files", "-T", default=[], action='append',
@@ -48,6 +46,7 @@ def pytest_generate_tests(metafunc):
     """
     :type metafunc: _pytest.python.Metafunc
     """
+    from . import run, refactor
     test_files = dict(map(parse_test_files_option,
                           metafunc.config.option.test_files))
     if 'case' in metafunc.fixturenames:
@@ -73,7 +72,6 @@ def isolated_jedi_cache(monkeypatch, tmpdir):
     Same as `clean_jedi_cache`, but create the temporary directory for
     each test case (scope='function').
     """
-    settings = base.jedi.settings
     monkeypatch.setattr(settings, 'cache_directory', str(tmpdir))
 
 
@@ -88,7 +86,6 @@ def clean_jedi_cache(request):
 
     This fixture is activated in ../pytest.ini.
     """
-    settings = base.jedi.settings
     old = settings.cache_directory
     tmp = tempfile.mkdtemp(prefix='jedi-test-')
     settings.cache_directory = tmp


### PR DESCRIPTION
Import refactored so that "import jedi.setting" and "import test.conftest"
imports currently only a small number of short files. Previously it imported
almost all files in the package. Some names use functional proxy for lazy import.
