### PR TITLE
Use coverage differently

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,4 +16,3 @@ deps =
 commands =
     coverage run --source jedi -m py.test
     coverage report
-    coverage erase


### PR DESCRIPTION
Use coverage directly not with `pytest-cov`, but directly using the `coverage` command.
