### PR TITLE
Add failing tests for the first part of #213 (definition not found for `from os.path import join`)

### DIFF
--- a/test/completion/import_tree/mod2.py
+++ b/test/completion/import_tree/mod2.py
@@ -1,0 +1,1 @@
+from . import mod1 as fake

--- a/test/completion/imports.py
+++ b/test/completion/imports.py
@@ -56,6 +56,27 @@ def scope_nested():
     #? set
     import_tree.random.a
 
+def scope_from_import_variable():
+    #? int()
+    from import_tree.mod2.fake import a
+    #? set
+    from import_tree.mod2.fake import c
+
+    #? int()
+    a
+    #? set
+    c
+
+def scope_from_import_variable_with_parenthesis():
+    from import_tree.mod2.fake import (
+        a, c
+    )
+
+    #? int()
+    a
+    #? set
+    c
+
 # -----------------
 # std lib modules
 # -----------------
@@ -206,7 +227,7 @@ import datetime.
 #? []
 import datetime.date
 
-#? 18 ['mod1', 'random', 'pkg', 'rename1', 'rename2', 'import']
+#? 18 ['mod1', 'mod2', 'random', 'pkg', 'rename1', 'rename2', 'import']
 from import_tree. import pkg
 
 #? 18 ['pkg']


### PR DESCRIPTION
See: #213
