### PR TITLE
Add sith.py, a script for random smoke test

### DIFF
--- a/sith.py
+++ b/sith.py
@@ -269,7 +269,7 @@ class AttackApp(object):
             description=__doc__)
         parser.add_argument(
             '--record', '-R', default='record.json',
-            help='Exceptions are recorded in here.')
+            help='Exceptions are recorded in here (default: %(default)s).')
         parser.add_argument(
             '--pdb', dest='debugger', const='pdb', action='store_const',
             help="Launch pdb when error is raised.")


### PR DESCRIPTION
It is very simple, but it finds errors with very small number of tries.  I think it is useful for debugging jedi.

```
% ./sith.py --help 
usage: sith.py [-h] [--record RECORD] [--pdb] [--ipdb] {random,redo,show} ...

Sith attacks (and helps debugging) Jedi.

Randomly search Python files and run Jedi on it.  Exception and used
arguments are recorded to ``./record.josn`` (specified by --record)::

    sith.py random

Redo recorded exception::

    sith.py redo

Fallback to pdb when error is raised::

    sith.py --pdb random
    sith.py --pdb redo

positional arguments:
  {random,redo,show}
    random            Randomly run Script().<method>() against files under
                      <rootpath>.
    redo              Redo recorded attack.
    show              Show recorded errors.

optional arguments:
  -h, --help          show this help message and exit
  --record RECORD     Exceptions are recorded in here.
  --pdb               Launch pdb when error is raised.
  --ipdb              Launch ipdb when error is raised.
```

fixes #128
