### PR TITLE
Add "sys.path" for pyenv.

### DIFF
--- a/jedi/modules.py
+++ b/jedi/modules.py
@@ -267,9 +267,10 @@ def get_sys_path():
 
 
     def check_pyenv(sys_path):
-
+        """ Add site-packages to the `sys.path` of pyenv's current version"""
+        # Check whether pyenv command exists
         pyenv_name = 'pyenv'
-        pyenv_pattern = re.compile('\.pyenv\/bin\/pyenv')
+        pyenv_pattern = re.compile('bin\/pyenv')
         pyenv_bin = None
         path = os.environ['PATH']
 
@@ -301,6 +302,7 @@ def get_sys_path():
             current_version = current_version.rstrip().decode()
             current_version = current_version.split()[0]
 
+            # Get pyenv's lib/pythonX.X/site-packages
             python_option_cmd = '"import sys; print(sys.version)"'
             python_raw_cmd = 'python -c {0}'.format(python_option_cmd)
             python_cmd = shlex.split(python_raw_cmd)


### PR DESCRIPTION
Hi Mr.davidhalter.

I always use "jedi-vim". It's my best favorite vim plugin.

But, not supported "pyenv". Do you know "pyenv"?
https://github.com/yyuu/pyenv 

"pyenv" constructs environments of python per-directory as following:
  For exmaple:
  /srv/python27 : You command "cd /srv/python27". You can use python2.7

I want to use "jedi-vim" under the pyenv.

So, I edited "jedi/modules.py", and made jedi be able to add pyenv's "sys.path". 
`~/.pyenv/versions/2.7.5/lib/python2.7/site-packages`(e.g:pyenv's python library directory).

Please merge my pull request, Mr.davidhalter. 
