### PR TITLE
Include everying in the test directory in source tarballs

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,10 @@ include README.rst
 include CHANGELOG.rst
 include LICENSE.txt
 include AUTHORS.txt
+include .coveragerc
+include conftest.py
+include pytest.ini
+include tox.ini
 include jedi/mixin/*.pym
 recursive-include test *
 recursive-exclude * *.pyc


### PR DESCRIPTION
There's really no reason not to do this, other than shaving a few bytes off the tarball. This would help us to better maintain the package over at Gentoo Linux as we can easily run the tests with each version bump.

Resolves #256.
