### PR TITLE
Work on making the REPL completion show names instead of dots

### DIFF
--- a/jedi/utils.py
+++ b/jedi/utils.py
@@ -128,22 +128,19 @@ def setup_readline(namespace_module=__main__):
         # re.UNICODE is technically not correct in Python 2, but it shouldn't hurt
         identifier = re.compile(r"[^\d\W]\w*$", re.UNICODE)
 
+        import rl.readline as readline
         def display_matches_hook(substitution, matches, longest_match_length):
-            print()
             rematch = identifier.search(substitution)
             pos = rematch.start() if rematch else len(substitution)
-            prefix = substitution[:pos]
             # At least spaces between matches
-            new_longest_match_length = longest_match_length - len(prefix) + 2
-            matches_per_line = TERM_WIDTH//new_longest_match_length
-            for i, match in enumerate(matches):
-                if i and not i % (matches_per_line-1):
-                    print()
-                print(match[pos:] + ' '*(new_longest_match_length -
-                    len(match[pos:])), end='')
-            print()
-            print(sys.ps1 + substitution, end='')
-            sys.stdout.flush()
+            newmatches = [match[pos:] for match in matches]
+            try:
+                import rl
+                rl.readline.display_match_list(substitution, newmatches,
+                    longest_match_length - pos)
+            except Exception as e:
+                print(e)
+            rl.readline.redisplay(force=True)
 
         readline.set_completion_display_matches_hook(display_matches_hook)
         readline.set_completer(JediRL().complete)
@@ -154,6 +151,6 @@ def setup_readline(namespace_module=__main__):
         readline.parse_and_bind("set show-all-if-unmodified")
         readline.parse_and_bind("set show-all-if-ambiguous on")
         # don't repeat all the things written in the readline all the time
-        readline.parse_and_bind("set completion-prefix-display-length 2")
+        #readline.parse_and_bind("set completion-prefix-display-length 2")
         # No delimiters, Jedi handles that.
         readline.set_completer_delims('')

--- a/jedi/utils.py
+++ b/jedi/utils.py
@@ -5,6 +5,9 @@ Utilities for end-users.
 from __future__ import absolute_import, print_function
 import __main__
 
+import sys
+import re
+
 from jedi import Interpreter
 
 
@@ -121,7 +124,6 @@ def setup_readline(namespace_module=__main__):
 
         TERM_WIDTH = terminal_width() or 80 # TODO: Better logic here
 
-        import re
         # For now, just show the end of the completion that's a keyword.
         # re.UNICODE is technically not correct in Python 2, but it shouldn't hurt
         identifier = re.compile(r"[^\d\W]\w*$", re.UNICODE)
@@ -135,10 +137,13 @@ def setup_readline(namespace_module=__main__):
             new_longest_match_length = longest_match_length - len(prefix) + 2
             matches_per_line = TERM_WIDTH//new_longest_match_length
             for i, match in enumerate(matches):
-                if i and not i % matches_per_line-1:
+                if i and not i % (matches_per_line-1):
                     print()
                 print(match[pos:] + ' '*(new_longest_match_length -
                     len(match[pos:])), end='')
+            print()
+            print(sys.ps1 + substitution, end='')
+            sys.stdout.flush()
 
         readline.set_completion_display_matches_hook(display_matches_hook)
         readline.set_completer(JediRL().complete)

--- a/jedi/utils.py
+++ b/jedi/utils.py
@@ -49,7 +49,7 @@ def setup_readline(namespace_module=__main__):
     bash).
 
     """
-    class JediRL():
+    class JediRL(object):
         def complete(self, text, state):
             """
             This complete stuff is pretty weird, a generator would make

--- a/jedi/utils.py
+++ b/jedi/utils.py
@@ -128,19 +128,28 @@ def setup_readline(namespace_module=__main__):
         # re.UNICODE is technically not correct in Python 2, but it shouldn't hurt
         identifier = re.compile(r"[^\d\W]\w*$", re.UNICODE)
 
-        import rl.readline as readline
-        def display_matches_hook(substitution, matches, longest_match_length):
+        from rl import readline, completer, completion
+
+        def display_matches_hook(substitution, matches, max_length):
             rematch = identifier.search(substitution)
             pos = rematch.start() if rematch else len(substitution)
             # At least spaces between matches
             newmatches = [match[pos:] for match in matches]
-            try:
-                import rl
-                rl.readline.display_match_list(substitution, newmatches,
-                    longest_match_length - pos)
-            except Exception as e:
-                print(e)
-            rl.readline.redisplay(force=True)
+            print(completer.query_items)
+            # if num_matches > completer.query_items >= 0:
+            #     sys.stdout.write('\nDisplay all %d possibilities? (y or n)' % num_matches)
+            #     sys.stdout.flush()
+            #     while True:
+            #         c = readline.read_key()
+            #         if c in 'yY\x20': # SPACEBAR
+            #             break
+            #         if c in 'nN\x7f': # RUBOUT
+            #             sys.stdout.write('\n')
+            #             completion.redisplay(force=True)
+            #             return
+            completion.display_match_list(substitution, newmatches, max_length
+                - pos)
+            completion.redisplay(force=True)
 
         readline.set_completion_display_matches_hook(display_matches_hook)
         readline.set_completer(JediRL().complete)


### PR DESCRIPTION
This is NOT ready to be merged. I am just opening a pull request so it is easier to see the code.  See https://github.com/davidhalter/jedi/issues/295.

So far:
- [ ] This will need to use the `rl` library. I believe that provides sufficient functions to make this really easy.
- [ ] I am using a regular expression to get the "completed" part out of the input, but surely Jedi provides an API for this. 

I think I know how to do the first point (if I'm not mistaken, http://pythonhosted.org/rl/readline.html#rl.readline.get_completion_display_matches_hook should help), but I'm not sure about the second. Any suggestions there would help. 
