### PR TITLE
Fix the Jedi REPL completion to work with IPython

### DIFF
--- a/jedi/utils.py
+++ b/jedi/utils.py
@@ -101,7 +101,6 @@ def setup_readline(namespace_module=__main__, combine_old_completer=False):
         if old_completer and combine_old_completer:
             completer = combine_completers(completer, old_completer)
         readline.set_completer(completer)
-        print(readline.get_completer())
         readline.parse_and_bind("tab: complete")
         # jedi itself does the case matching
         readline.parse_and_bind("set completion-ignore-case on")


### PR DESCRIPTION
Previously, it wasn't really working (it just looked like it did because it
set the completer to use `...`). The reason is that IPython resets the completer
to its own completer after every prompt. The solution is to detect when we are
in IPython and disable its readline support.
