### PR TITLE
Fix for pyqt errors with python 2.7

### DIFF
--- a/test/test_regression.py
+++ b/test/test_regression.py
@@ -169,8 +169,3 @@ class TestRegression(TestCase):
             "    yield 1\n" \
             "abc()."
         assert Script(s).completions()
-
-    def test_pyqt(self):
-        code = "from PyQt4.Qt import QDialog; QDialog."
-        s = jedi.Script(code)
-        assert s.completions()


### PR DESCRIPTION
The cause of the error is that unbound pyqt signals do not have a `__name__` attribute.

E.g, running the following script will raise an AttributeError

``` python
from PyQt4 import QtGui
print(QtGui.QAbstractButton.clicked.__name__)
```

The fix is very simple, return `' ', 'pass'` if the func object does not have a `__name__` attribute (as if there was no docstring)

The error didn't show up in 0.6.0 because it seems like jedi was missing the signals attribute of pyqt objects.

Note that there are actually two issues in #331: 
- jedi.common.UncaughtAttributeError: 'PyQt4.QtCore.pyqtSignal' object has no attribute '**name**'
- ImportError: No module named 'Qt'

This PR does not fix the last issue.

I have added a regression test in test/test_regression.py. I am not sure if this is the best place, just tell me if you want to move the test somewhere else.
