### PR TITLE
Allow Jedi to be imported from a REPL on Windows

### DIFF
--- a/jedi/debug.py
+++ b/jedi/debug.py
@@ -8,7 +8,9 @@ try:
         # Use colorama for nicer console output.
         from colorama import Fore, init
         init()
-    # does not work on Windows, as pyreadline and colorama interfere
+        # does not work on Windows, as pyreadline and colorama interfere
+    else:
+        raise ImportError
 except ImportError:
     class Fore(object):
         RED = ''


### PR DESCRIPTION
Colorama and Pyreadline interfere on Windows, causing the mere act of importing Jedi from the Python prompt to cause a scrolling set of errors (see #364).  
This PR adds an `os.name` check to `debug.py`, allowing for `colorama` support on all other platforms, but avoiding the troublesome behavior on Windows.  I tested this on Windows 7 64 bit and Linux Mint 16 32 bit.
