### PR TITLE
Add a module to test the memory usage with large libaries

### DIFF
--- a/scripts/memory_check.py
+++ b/scripts/memory_check.py
@@ -1,0 +1,53 @@
+"""
+This is a convenience script to test the speed and memory usage of Jedi with
+large libraries.
+
+Each library is preloaded by jedi, recording the time and memory consumed by
+each operation.
+
+You can provide additional libraries via command line arguments.
+
+Note: This requires the psutil library, available on PyPI.
+"""
+import time
+import sys
+import psutil
+import jedi
+
+
+def used_memory():
+    """Return the total MB of System Memory in use."""
+    return psutil.virtual_memory().used / 2**20
+
+
+def profile_preload(mod):
+    """Preload a module into Jedi, recording time and memory used."""
+    base = used_memory()
+    t0 = time.time()
+    jedi.preload_module(mod)
+    elapsed = time.time() - t0
+    used = used_memory() - base
+    return elapsed, used
+
+
+def main(mods):
+    """Preload the modules, and print the time and memory used."""
+    t0 = time.time()
+    baseline = used_memory()
+    print('Time (s) | Mem (MB) | Package')
+    print('------------------------------')
+    for mod in mods:
+        elapsed, used = profile_preload(mod)
+        if used > 0:
+            print('%8.1f | %8d | %s' % (elapsed, used, mod))
+    print('------------------------------')
+    elapsed = time.time() - t0
+    used = used_memory() - baseline
+    print('%8.1f | %8d | %s' % (elapsed, used, 'Total'))
+
+
+if __name__ == '__main__':
+    mods = ['re', 'numpy', 'scipy', 'scipy.sparse', 'scipy.stats',
+            'wx', 'decimal', 'PyQt4.QtGui', 'PySide.QtGui', 'Tkinter']
+    mods += sys.argv[1:]
+    main(mods)


### PR DESCRIPTION
This is a convenience script to test the speed and memory usage of Jedi with large libraries.

Each library is preloaded by jedi, recording the time and memory consumed by each operation.

You can provide additional libraries via command line arguments.

Note: This requires the psutil library, available on PyPI.

The following are the outputs of runs just after deleting the Jedi cache and then running a second time.

```
Time (s) | Mem (MB) | Package
------------------------------
     0.1 |        1 | re
     6.3 |       35 | numpy
     2.1 |        9 | scipy.sparse
     7.0 |       46 | scipy.stats
     2.5 |        6 | decimal
     0.1 |        1 | PySide.QtGui
     2.3 |       13 | Tkinter
------------------------------
    20.6 |      111 | Total

Time (s) | Mem (MB) | Package
------------------------------
     0.0 |        2 | re
     1.2 |       28 | numpy
     0.4 |        7 | scipy.sparse
     1.4 |       37 | scipy.stats
     0.4 |        6 | decimal
     0.1 |        2 | PySide.QtGui
     0.5 |        9 | Tkinter
------------------------------
     4.1 |       91 | Total
```
