### PR TITLE
Reproduce Issue 402

### DIFF
--- a/jedi/evaluate/imports.py
+++ b/jedi/evaluate/imports.py
@@ -408,6 +408,7 @@ class _Importer(object):
                 path += '/__init__.py'
                 with open(path, 'rb') as f:
                     source = f.read()
+                    source = source.replace(b'\n', b'\r\n')
             else:
                 source = current_namespace[0].read()
                 current_namespace[0].close()

--- a/test/test_regression.py
+++ b/test/test_regression.py
@@ -171,3 +171,8 @@ def test_loading_unicode_files_with_bad_global_charset(monkeypatch, tmpdir):
     s = Script("from test1 import foo\nfoo.",
                line=2, column=4, path=filename2)
     s.complete()
+
+
+def test_bug_402():
+    script = Script('import jedi; s = jedi.Script(''); s.')
+    assert len(script.completions())


### PR DESCRIPTION
This pull request aims to reproduce bug #402 on a GNU/Linux system (i.e. on Travis CI).

I changed '\n' to '\r\n' in `jedi/evaluate/imports.py`  to reproduce the behaviour I observed on Windows. I also added a test which should reproduce bug #402 in `test/test_regresion:test_bug_402`.
