### PR TITLE
Print the Jedi version when REPL completion is used

### DIFF
--- a/jedi/api/replstartup.py
+++ b/jedi/api/replstartup.py
@@ -15,9 +15,13 @@ Then you will be able to use Jedi completer in your Python interpreter::
     os.path.join().split().index   os.path.join().split().insert
 
 """
-
 import jedi.utils
+from jedi import __version__ as __jedi_version__
+
+print('REPL completion using Jedi %s' % __jedi_version__)
 jedi.utils.setup_readline()
+
 del jedi
+
 # Note: try not to do many things here, as it will contaminate global
 # namespace of the interpreter.


### PR DESCRIPTION
```
[repl_info]danilo@x2000:jedi$ PYTHONSTARTUP="/home/danilo/Projects/jedi/jedi/api/replstartup.py" python
Python 3.4.0 (default, Mar 17 2014, 23:20:09) 
[GCC 4.8.2 20140206 (prerelease)] on linux
Type "help", "copyright", "credits" or "license" for more information.
REPL completion using Jedi 0.8.0-final0
>>> 
```

This also makes debugging easier, because people see which completion they're actually using.

Maybe there should be a way to turn it off though? Is this even useful at all?
