### PR TITLE
Fix completion params

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -23,5 +23,6 @@ srusskih (@srusskih)
 Steven Silvester (@blink1073)
 Colin Duquesnoy (@ColinDuquesnoy) <colin.duquesnoy@gmail.com>
 Jorgen Schaefer (@jorgenschaefer) <contact@jorgenschaefer.de>
+Fredrik Bergroth (@fbergroth)
 
 Note: (@user) means a github user name.

--- a/jedi/api/classes.py
+++ b/jedi/api/classes.py
@@ -307,11 +307,12 @@ class BaseDefinition(object):
         stripped = self._definition
         if isinstance(stripped, pr.Name):
             stripped = stripped.parent
-            # We should probably work in `Finder._names_to_types` here.
-            if isinstance(stripped, pr.Function):
-                stripped = er.Function(self._evaluator, stripped)
-            elif isinstance(stripped, pr.Class):
-                stripped = er.Class(self._evaluator, stripped)
+
+        # We should probably work in `Finder._names_to_types` here.
+        if isinstance(stripped, pr.Function):
+            stripped = er.Function(self._evaluator, stripped)
+        elif isinstance(stripped, pr.Class):
+            stripped = er.Class(self._evaluator, stripped)
 
         if stripped.isinstance(pr.Statement):
             return self._evaluator.eval_statement(stripped)

--- a/test/test_api/test_api_classes.py
+++ b/test/test_api/test_api_classes.py
@@ -127,6 +127,11 @@ def test_completion_docstring():
     assert c.docstring(raw=True, fast=False) == cleandoc(Script.__doc__)
 
 
+def test_completion_params():
+    c = Script('import string; string.capwords').completions()[0]
+    assert [p.name for p in c.params] == ['s', 'sep']
+
+
 def test_signature_params():
     def check(defs):
         params = defs[0].params


### PR DESCRIPTION
I ran into the following problem when trying to grab the params from a completion:

``` python
>>> import jedi
>>> c = jedi.Script('import string; string.capwords').completions()[0]
>>> c.params # raises AttributeError
>>> c._definition.params # but this works
[<Param: s @33,13>, <Param: sep = None @33,16>]
```

To me, it looked like the `pr` to `er` cast should always happen irregardless of `self._definition` being a `pr.Name`. But I'm not too confident here. :)
Cheers
