### PR TITLE
Fix package_data '*.pym' paths

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -25,5 +25,6 @@ Colin Duquesnoy (@ColinDuquesnoy) <colin.duquesnoy@gmail.com>
 Jorgen Schaefer (@jorgenschaefer) <contact@jorgenschaefer.de>
 Fredrik Bergroth (@fbergroth)
 Mathias Fußenegger (@mfussenegger)
+Syohei Yoshida (@syohex) <syohex@gmail.com>
 
 Note: (@user) means a github user name.

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(name='jedi',
       keywords='python completion refactoring vim',
       long_description=readme,
       packages=['jedi', 'jedi.parser', 'jedi.evaluate', 'jedi.evaluate.compiled', 'jedi.api'],
-      package_data={'jedi': ['evlaluate/evaluate/compiled/fake/*.pym']},
+      package_data={'jedi': ['evaluate/compiled/fake/*.pym']},
       platforms=['any'],
       classifiers=[
           'Development Status :: 4 - Beta',


### PR DESCRIPTION
`*.pym` files are not installed when `python setup.py install`
because `package_data` paths are wrong.
