### PR TITLE
The cause of error seems is the line contains multibyte words.

### DIFF
--- a/jedi/parser/user_context.py
+++ b/jedi/parser/user_context.py
@@ -144,20 +144,22 @@ class UserContext(object):
     def get_context(self, yield_positions=False):
         self.get_path_until_cursor()  # In case _start_cursor_pos is undefined.
         pos = self._start_cursor_pos
+        start_cursor = pos[1]
         while True:
             # remove non important white space
             line = self.get_line(pos[0])
             while True:
-                if pos[1] == 0:
+                if start_cursor == 0:
                     line = self.get_line(pos[0] - 1)
                     if line and line[-1] == '\\':
                         pos = pos[0] - 1, len(line) - 1
                         continue
                     else:
                         break
-
-                if line[pos[1] - 1].isspace():
-                    pos = pos[0], pos[1] - 1
+                if len(line) <= start_cursor:
+                    break
+                if line[start_cursor - 1].isspace():
+                    pos = pos[0], start_cursor - 1
                 else:
                     break
 


### PR DESCRIPTION
The cause of error seems is the line contains multibyte words.
The message is as below.

```
Traceback (most recent call last):
  File "/Users/XXX/.neobundle/jedi-vim/jedi_vim.py", line 23, in wrapper
    return func(*args, **kwargs)
  File "/Users/XXX/.neobundle/jedi-vim/jedi_vim.py", line 252, in show_call_signatures
    signatures = get_script().call_signatures()
  File "/Users/XXX/.neobundle/jedi-vim/jedi/jedi/api/__init__.py", line 555, in call_signatures
    user_stmt = self._parser.user_stmt_with_whitespace()
  File "/Users/XXX/.neobundle/jedi-vim/jedi/jedi/cache.py", line 141, in wrapper
    result = func(self)
  File "/Users/XXX/.neobundle/jedi-vim/jedi/jedi/parser/user_context.py", line 237, in user_stmt_with_whitespace
    pos = next(self._user_context.get_context(yield_positions=True))
  File "/Users/XXX/.neobundle/jedi-vim/jedi/jedi/parser/user_context.py", line 159, in get_context
    if line[pos[1] - 1].isspace():
IndexError: string index out of range
```

I can't see the whole project, so my patch may be a stopgap.
And sorry for patch #425. the patch could cause infinite loop...
