### PR TITLE
Sphinx oneline param type declaration feature

### DIFF
--- a/docs/docs/features.rst
+++ b/docs/docs/features.rst
@@ -119,10 +119,11 @@ http://sphinx-doc.org/domains.html#info-field-lists
 
 ::
 
-    def myfunction(node):
+    def myfunction(node, foo):
         """Do something with a ``node``.
 
         :type node: ProgramNode
+        :param str foo: foo parameter description
 
         """
         node.| # complete here

--- a/jedi/evaluate/docstrings.py
+++ b/jedi/evaluate/docstrings.py
@@ -24,6 +24,7 @@ from jedi.common import indent_block
 
 DOCSTRING_PARAM_PATTERNS = [
     r'\s*:type\s+%s:\s*([^\n]+)',  # Sphinx
+    r'\s*:param\s+(\w+)\s+%s:[^\n]+', # Sphinx param with type
     r'\s*@type\s+%s:\s*([^\n]+)',  # Epydoc
 ]
 
@@ -55,6 +56,8 @@ def _search_param_in_docstr(docstr, param_str):
     'threading.Thread'
     >>> _search_param_in_docstr('no document', 'param') is None
     True
+    >>> _search_param_in_docstr(':param int param: some description', 'param')
+    'int'
 
     """
     # look at #40 to see definitions of those params

--- a/test/completion/docstring.py
+++ b/test/completion/docstring.py
@@ -3,13 +3,14 @@
 # -----------------
 # sphinx style
 # -----------------
-def f(a, b, c, d):
+def f(a, b, c, d, x):
     """ asdfasdf
     :param a: blablabla
     :type a: str
     :type b: (str, int)
     :type c: threading.Thread
     :type d: :class:`threading.Thread`
+    :param str x: blablabla
     :rtype: dict
     """
     #? str()
@@ -22,23 +23,28 @@ def f(a, b, c, d):
     c.join
     #? ['join']
     d.join
+    #? ['lower']
+    x.lower
 
 #? dict()
 f()
 
 # wrong declarations
-def f(a, b):
+def f(a, b, x):
     """
     :param a: Forgot type declaration
     :type a:
     :param b: Just something
     :type b: ``
-    :rtype: 
+    :param x: Just something without type
+    :rtype:
     """
     #? 
     a
     #? 
     b
+    #?
+    x
 
 #? 
 f()

--- a/test/test_evaluate/test_docstring.py
+++ b/test/test_evaluate/test_docstring.py
@@ -50,6 +50,16 @@ class TestDocstring(unittest.TestCase):
         names = [c.name for c in jedi.Script(s).completions()]
         assert 'start' in names
 
+    def test_docstrings_param_type(self):
+        s = """
+                def func(arg):
+                    '''
+                    :param str arg: some description
+                    '''
+                    arg."""
+        names = [c.name for c in jedi.Script(s).completions()]
+        assert 'join' in names
+
     def test_docstrings_type_str(self):
         s = """
                 def func(arg):


### PR DESCRIPTION
Allows for type hinting in ":param TYPE NAME:" format like three first examples in http://sphinx-doc.org/domains.html#info-field-lists.
