### PR TITLE
Alter jedi.Interpreter() namespace argument default from [] to [{}]

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -26,5 +26,6 @@ Jorgen Schaefer (@jorgenschaefer) <contact@jorgenschaefer.de>
 Fredrik Bergroth (@fbergroth)
 Mathias Fußenegger (@mfussenegger)
 Syohei Yoshida (@syohex) <syohex@gmail.com>
+Phillip Berndt (@phillipberndt) <phillip.berndt@gmail.com>
 
 Note: (@user) means a github user name.

--- a/jedi/api/__init__.py
+++ b/jedi/api/__init__.py
@@ -621,7 +621,7 @@ class Interpreter(Script):
     upper
     """
 
-    def __init__(self, source, namespaces=[], **kwds):
+    def __init__(self, source, namespaces, **kwds):
         """
         Parse `source` and mixin interpreted Python objects from `namespaces`.
 
@@ -635,6 +635,10 @@ class Interpreter(Script):
         If `line` and `column` are None, they are assumed be at the end of
         `source`.
         """
+        if type(namespaces) is not list or len(namespaces) == 0 or \
+           any([type(x) is not dict for x in namespaces]):
+            raise TypeError("namespaces must be a non-empty list of dict")
+
         super(Interpreter, self).__init__(source, **kwds)
         self.namespaces = namespaces
 


### PR DESCRIPTION
A few lines into the constructor, an `Interpreter` calls

```
    # Here we add the namespaces to the current parser.
    interpreter.create(self._evaluator, namespaces[0], self._parser.module())
```

The default value for the `namespaces` parameter currently is `[]`, such that an exception is thrown. I've changed that default to `[{}]`.
