### PR TITLE
Add any .egg-link paths from VIRTUAL_ENV to sys.path

### DIFF
--- a/jedi/evaluate/sys_path.py
+++ b/jedi/evaluate/sys_path.py
@@ -1,3 +1,4 @@
+import glob
 import os
 import sys
 
@@ -23,6 +24,10 @@ def get_sys_path():
                              'site-packages')
         if p not in sys_path:
             sys_path.insert(0, p)
+
+        # Add all egg-links from the virtualenv.
+        for egg_link in glob.glob(os.path.join(p, '*.egg-link')):
+            sys_path.insert(0, open(egg_link).readline().rstrip())
 
     check_virtual_env(sys.path)
     return [p for p in sys.path if p != ""]


### PR DESCRIPTION
I've noticed that Jedi does not appear to handle packages that are installed using `pip install -e`, where an `.egg-link` is being used in the virtualenv, e.g.:

    $VIRTUAL_ENV/lib/python2.7/site-packages/Django.egg-link

This PR fixes this by adding the contents of all `.egg-link` files to `sys.path`.

There might be a better method, e.g. some helper from setuptools or something similar though?!