### PR TITLE
HACK: append sys.path from other major python via subprocess

### DIFF
--- a/jedi/evaluate/sys_path.py
+++ b/jedi/evaluate/sys_path.py
@@ -24,6 +24,18 @@ def get_sys_path():
         if p not in sys_path:
             sys_path.insert(0, p)
 
+    # HACK: add sys.path from python3 and vice versa.
+    import subprocess
+    other_python = 'python%d' % (22 if sys.version_info.major == 3 else 3,)
+    try:
+        other_sys_path = subprocess.check_output(
+            [other_python, '-c', 'import sys; print(sys.path)']).decode('utf-8')
+    except OSError:
+        pass
+    else:
+        other_sys_path = other_sys_path[2:-3].split("', '")
+        sys.path += other_sys_path
+
     check_virtual_env(sys.path)
     return [p for p in sys.path if p != ""]
 


### PR DESCRIPTION
This makes working with Python 2 and 3 in parallel less painfull.

My use case is Jedi being used in Vim via YouCompleteMe, which only
supports Python 2, but I'd like to use the completion also when editing
Python 3 files.

What do you think? Is this a approach in the right direction?
See also #535 (API to adjust sys.path).