### PR TITLE
Dynamic check for VIRTUAL_ENV python version

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -33,5 +33,6 @@ Savor d'Isavano (@KenetJervet) <newelevenken@163.com>
 Phillip Berndt (@phillipberndt) <phillip.berndt@gmail.com>
 Ian Lee (@IanLee1521) <IanLee1521@gmail.com>
 Farkhad Khatamov (@hatamov) <comsgn@gmail.com>
+Tony Walker (@walkert) <tonywalker.uk@gmail.com>
 
 Note: (@user) means a github user name.

--- a/jedi/evaluate/sys_path.py
+++ b/jedi/evaluate/sys_path.py
@@ -33,8 +33,15 @@ def _get_venv_sitepackages(venv):
     if os.name == 'nt':
         p = os.path.join(venv, 'lib', 'site-packages')
     else:
-        p = os.path.join(venv, 'lib', 'python%d.%d' % sys.version_info[:2],
-                         'site-packages')
+        # Account for the VIRTUAL_ENV using an alternate python verison
+        venv_lib = os.path.join(venv, 'lib')
+        try:
+            pyver = [p for p in os.listdir(venv_lib) if
+                     p.startswith('python')][0]
+            p = os.path.join(venv_lib, pyver, 'site-packages')
+        except IndexError:
+            # There should always be a 'pythonX.X' file, but just in case
+            p = ''
     return p
 
 

--- a/jedi/evaluate/sys_path.py
+++ b/jedi/evaluate/sys_path.py
@@ -1,5 +1,6 @@
 import glob
 import os
+import re
 import sys
 
 from jedi._compatibility import exec_function, unicode
@@ -30,6 +31,7 @@ def get_sys_path():
     return [p for p in sys.path if p != ""]
 
 def _get_venv_sitepackages(venv):
+    pyre = re.compile('^python\d\.\d$')
     if os.name == 'nt':
         p = os.path.join(venv, 'lib', 'site-packages')
     else:
@@ -37,7 +39,7 @@ def _get_venv_sitepackages(venv):
         venv_lib = os.path.join(venv, 'lib')
         try:
             pyver = [p for p in os.listdir(venv_lib) if
-                     p.startswith('python')][0]
+                     pyre.search(p)][0]
             p = os.path.join(venv_lib, pyver, 'site-packages')
         except IndexError:
             # There should always be a 'pythonX.X' file, but just in case


### PR DESCRIPTION
Previously, an assumption was made that the virtualenv was created using
a python version that matched sys.version_info[:2]. If this was not the
case, an invalid path is added to sys.path and we don't get any
completion.

This commit checks the 'pythonX.X' file within $VIRTUAL_ENV/lib and sets
the path accordingly. The test_get_sys_path() test has been updated to
properly test this by mocking os.listdir().
