### PR TITLE
Improve virtualenv support & egg-link resolution

### DIFF
--- a/jedi/evaluate/__init__.py
+++ b/jedi/evaluate/__init__.py
@@ -61,6 +61,7 @@ that are not used are just being ignored.
 """
 
 import copy
+import sys
 from itertools import chain
 
 from jedi.parser import tree
@@ -79,7 +80,7 @@ from jedi.evaluate import helpers
 
 
 class Evaluator(object):
-    def __init__(self, grammar):
+    def __init__(self, grammar, sys_path=None):
         self.grammar = grammar
         self.memoize_cache = {}  # for memoize decorators
         # To memorize modules -> equals `sys.modules`.
@@ -88,6 +89,13 @@ class Evaluator(object):
         self.recursion_detector = recursion.RecursionDetector()
         self.execution_recursion_detector = recursion.ExecutionRecursionDetector()
         self.analysis = []
+        if sys_path is None:
+            sys_path = sys.path
+        self.sys_path = copy.copy(sys_path)
+        try:
+            self.sys_path.remove('')
+        except ValueError:
+            pass
 
     def wrap(self, element):
         if isinstance(element, tree.Class):

--- a/jedi/evaluate/imports.py
+++ b/jedi/evaluate/imports.py
@@ -342,7 +342,7 @@ class Importer(object):
             module_file.close()
 
         if module_file is None and not module_path.endswith('.py'):
-            module = compiled.load_module(module_path)
+            module = compiled.load_module(self._evaluator, module_path)
         else:
             module = _load_module(self._evaluator, module_path, source, sys_path)
 
@@ -440,11 +440,14 @@ def _load_module(evaluator, path=None, source=None, sys_path=None):
                 with open(path, 'rb') as f:
                     source = f.read()
         else:
-            return compiled.load_module(path)
+            return compiled.load_module(evaluator, path)
         p = path
         p = fast.FastParser(evaluator.grammar, common.source_to_unicode(source), p)
         cache.save_parser(path, p)
         return p.module
+
+    if sys_path is None:
+        sys_path = evaluator.sys_path
 
     cached = cache.load_parser(path)
     module = load(source) if cached is None else cached.module

--- a/jedi/evaluate/sys_path.py
+++ b/jedi/evaluate/sys_path.py
@@ -71,7 +71,7 @@ def _get_venv_path_online(venv):
             break
     else:
         raise RuntimeError("Cannot find python executable in venv: %s" % venv)
-    command = [python_path, '-c', 'import sys; print(sys.path)']
+    command = [python_path, '-E', '-c', 'import sys; print(sys.path)']
     return literal_eval(check_output(command))
 
 

--- a/jedi/evaluate/sys_path.py
+++ b/jedi/evaluate/sys_path.py
@@ -1,6 +1,9 @@
 import glob
 import os
 import sys
+from subprocess import check_output
+from ast import literal_eval
+from site import addsitedir
 
 from jedi._compatibility import exec_function, unicode
 from jedi.parser import tree
@@ -11,24 +14,66 @@ from jedi import common
 from jedi import cache
 
 
-def get_sys_path():
-    def check_virtual_env(sys_path):
-        """ Add virtualenv's site-packages to the `sys.path`."""
-        venv = os.getenv('VIRTUAL_ENV')
-        if not venv:
-            return
-        venv = os.path.abspath(venv)
-        p = _get_venv_sitepackages(venv)
-        if p not in sys_path:
-            sys_path.insert(0, p)
+def get_venv_path(venv):
+    """Get sys.path for specified virtual environment."""
+    try:
+        sys_path = _get_venv_path_online(venv)
+    except Exception as e:
+        debug.warning("Error when getting venv path: %s" % e)
+        sys_path = _get_venv_path_offline(venv)
+    with common.ignored(ValueError):
+        sys_path.remove('')
+    return _get_sys_path_with_egglinks(sys_path)
 
-        # Add all egg-links from the virtualenv.
+
+def _get_sys_path_with_egglinks(sys_path):
+    """Find all paths including those referenced by egg-links.
+
+    Egg-link-referenced directories are inserted into path immediately after
+    the directory on which their links were found.  Such directories are not
+    taken into consideration by normal import mechanism, but they are traversed
+    when doing pkg_resources.require.
+    """
+    result = []
+    for p in sys_path:
+        result.append(p)
         for egg_link in glob.glob(os.path.join(p, '*.egg-link')):
             with open(egg_link) as fd:
-                sys_path.insert(0, fd.readline().rstrip())
+                for line in fd:
+                    line = line.strip()
+                    if line:
+                        result.append(os.path.join(p, line))
+                        # pkg_resources package only interprets the first
+                        # non-empty line in egg-link files.
+                        break
+    return result
 
-    check_virtual_env(sys.path)
-    return [p for p in sys.path if p != ""]
+
+def _get_venv_path_offline(venv):
+    """Get sys.path for venv without starting up the interpreter."""
+    venv = os.path.abspath(venv)
+    sitedir = _get_venv_sitepackages(venv)
+    sys.path, old_sys_path = [], sys.path
+    try:
+        addsitedir(sitedir)
+        return sys.path
+    finally:
+        sys.path = old_sys_path
+
+
+def _get_venv_path_online(venv):
+    """Get sys.path for venv by running its python interpreter."""
+    venv = os.path.abspath(os.path.expanduser(venv))
+    for python_binary in ('python', 'python3', 'python.exe',
+                          'python3.exe'):
+        python_path = os.path.join(venv, 'bin', python_binary)
+        if os.path.isfile(python_path):
+            break
+    else:
+        raise RuntimeError("Cannot find python executable in venv: %s" % venv)
+    command = [python_path, '-c', 'import sys; print(sys.path)']
+    return literal_eval(check_output(command))
+
 
 
 def _get_venv_sitepackages(venv):
@@ -109,7 +154,6 @@ def _paths_from_list_modifications(module_path, trailer1, trailer2):
     name = trailer1.children[1].value
     if name not in ['insert', 'append']:
         return []
-
     arg = trailer2.children[1]
     if name == 'insert' and len(arg.children) in (3, 4):  # Possible trailing comma.
         arg = arg.children[2]
@@ -117,6 +161,9 @@ def _paths_from_list_modifications(module_path, trailer1, trailer2):
 
 
 def _check_module(evaluator, module):
+    """
+    Detect sys.path modifications within module.
+    """
     def get_sys_path_powers(names):
         for name in names:
             power = name.parent.parent
@@ -128,10 +175,12 @@ def _check_module(evaluator, module):
                     if isinstance(n, tree.Name) and n.value == 'path':
                         yield name, power
 
-    sys_path = list(get_sys_path())  # copy
+    sys_path = list(evaluator.sys_path)  # copy
     try:
         possible_names = module.used_names['path']
     except KeyError:
+        # module.used_names is MergedNamesDict whose getitem never throws
+        # keyerror, this is superfluous.
         pass
     else:
         for name, power in get_sys_path_powers(possible_names):
@@ -148,7 +197,7 @@ def sys_path_with_modifications(evaluator, module):
     if module.path is None:
         # Support for modules without a path is bad, therefore return the
         # normal path.
-        return list(get_sys_path())
+        return list(evaluator.sys_path)
 
     curdir = os.path.abspath(os.curdir)
     with common.ignored(OSError):

--- a/test/test_regression.py
+++ b/test/test_regression.py
@@ -66,8 +66,9 @@ class TestRegression(TestCase):
         src1 = "def r(a): return a"
         # Other fictional modules in another place in the fs.
         src2 = 'from .. import setup; setup.r(1)'
-        imports.load_module(os.path.abspath(fname), src2)
-        result = Script(src1, path='../setup.py').goto_definitions()
+        script = Script(src1, path='../setup.py')
+        imports.load_module(script._evaluator, os.path.abspath(fname), src2)
+        result = script.goto_definitions()
         assert len(result) == 1
         assert result[0].description == 'class int'
 


### PR DESCRIPTION
AFAIU, it is generally considered ok to mix jedi's own sys.path and virtualenv paths, but recently I have run into a conflict between setuptools/distribute found in:
- jedi's virtualenv
- user site directory (`$HOME/.local/lib/pythonX.X/site-packages`)
- virtualenv I was actually using

This conflict caused problems in resolving something as simple as `setuptools.setup` and made me rethink module resolution towards "purity". 

This PR adds the following:
- add sys_path= kwarg to Script & Evaluator constructors
- store sys_path for each evaluator instance (closes #384)
- add get_venv_path(venv) function to determine virtualenv's path:
  - by default, dump path from live python interpreter
  - use old path extension variant for fallback
  - in old variant, use addsitedir to load .pth extension files (closes #443)
- look for egg-link files in all directories in path

Several discussion questions here:
- starting python interpreter from the virtualenv is the most precise way to know its sys.path, but are there drawbacks besides process startup overhead? e.g. should we clean `PYTHONSTARTUP` env var?
- if running python interpreter is ok, how do we test it? 
- as path resolution grows more and more heavy (.pth, egg-links, now subprocesses), do we need to cache it somehow? and for a long-running jedi process, like ycmd, how do we flush the cache to reflect package installation/removal.
- is there a use case for removing `site.USER_SITE` from lookups, too?