### PR TITLE
Try not to fail if someone sets a weird encoding

### DIFF
--- a/jedi/common.py
+++ b/jedi/common.py
@@ -140,8 +140,11 @@ def source_to_unicode(source, encoding=None):
         # only cast str/bytes
         return source
 
-    # cast to unicode by default
-    return unicode(source, detect_encoding(), 'replace')
+    try:
+        return unicode(source, detect_encoding(), 'replace')
+    except LookupError:
+        # If people do not adhere to PEP 263, try to fall back to UTF-8 for improved compability
+        return unicode(source, 'utf-8', 'replace')
 
 
 def splitlines(string):


### PR DESCRIPTION
See https://github.com/tinloaf/autocomplete-plus-python-jedi/issues/1
for reference.

There, @v3ss0n had the problem that Jedi seemed to detect a wrong encoding ('iso-latin-1-unix') for a file of the project and fails. This patch will (if unicode conversion fails) try a UTF-8 fallback, which seems like a sane default for me.

I can't reproduce the problem that @v3ss0n had, but I'm pretty sure this should have fixed it, since adding a "coding: utf-8" - header to that file fixed it for him, too.