### PR TITLE
AttributeError with ValueError in _compatibility.py:find_module_py33

### DIFF
--- a/jedi/_compatibility.py
+++ b/jedi/_compatibility.py
@@ -25,7 +25,7 @@ def find_module_py33(string, path=None):
         except ValueError as e:
             # See #491. Importlib might raise a ValueError, to avoid this, we
             # just raise an ImportError to fix the issue.
-            raise ImportError("Originally ValueError: " + e.message)
+            raise ImportError("Originally ValueError: " + str(e))
 
     if loader is None:
         raise ImportError("Couldn't find a loader for {0}".format(string))


### PR DESCRIPTION
I came across the following error (via jedi-vim).

      File "…/vim/neobundles/jedi/jedi/jedi/_compatibility.py", line 28, in find_module_py33
        raise ImportError("Originally ValueError: " + e.message)

If I remember correctly it should use `e.args` here.


Traceback:

> AttributeError: 'ValueError' object has no attribute 'message'

    Traceback (most recent call last):
      File "…/pyenv/3.4.3/lib/python3.4/importlib/__init__.py", line 68, in find_loader
        loader = sys.modules[name].__loader__
    AttributeError: 'Nvim' object has no attribute '__loader__'
    During handling of the above exception, another exception occurred:
    Traceback (most recent call last):
      File "…/vim/neobundles/jedi/jedi/jedi/_compatibility.py", line 24, in find_module_py33
        loader = importlib.find_loader(string)
      File "…/pyenv/3.4.3/lib/python3.4/importlib/__init__.py", line 76, in find_loader
        raise ValueError('{}.__loader__ is not set'.format(name))
    ValueError: vim.__loader__ is not set
    During handling of the above exception, another exception occurred:
    Traceback (most recent call last):
      File "…/vim/neobundles/jedi/jedi_vim.py", line 107, in wrapper
        return func(*args, **kwargs)
      File "…/vim/neobundles/jedi/jedi_vim.py", line 206, in goto
        definitions = script.goto_definitions()
      File "…/vim/neobundles/jedi/jedi/jedi/api/__init__.py", line 362, in goto_definitions
        definitions = set(self._prepare_goto(goto_path))
      File "…/vim/neobundles/jedi/jedi/jedi/api/__init__.py", line 294, in _prepare_goto
        scopes = self._evaluator.eval_element(eval_stmt)
      File "…/vim/neobundles/jedi/jedi/jedi/evaluate/cache.py", line 41, in wrapper
        rv = function(obj, *args, **kwargs)
      File "…/vim/neobundles/jedi/jedi/jedi/evaluate/__init__.py", line 169, in eval_element
        return self._eval_atom(element)
      File "…/vim/neobundles/jedi/jedi/jedi/evaluate/__init__.py", line 230, in _eval_atom
        return self.find_types(scope, atom, stmt.start_pos, search_global=True)
      File "…/vim/neobundles/jedi/jedi/jedi/evaluate/__init__.py", line 120, in find_types
        return f.find(scopes, search_global)
      File "…/vim/neobundles/jedi/jedi/jedi/debug.py", line 52, in wrapper
        result = func(*args, **kwargs)
      File "…/vim/neobundles/jedi/jedi/jedi/evaluate/finder.py", line 87, in find
        types = self._names_to_types(names, search_global)
      File "…/vim/neobundles/jedi/jedi/jedi/evaluate/finder.py", line 233, in _names_to_types
        new_types = _name_to_types(self._evaluator, name, self.scope)
      File "…/vim/neobundles/jedi/jedi/jedi/evaluate/cache.py", line 41, in wrapper
        rv = function(obj, *args, **kwargs)
      File "…/vim/neobundles/jedi/jedi/jedi/evaluate/finder.py", line 278, in _name_to_types
        types += _remove_statements(evaluator, typ, name)
      File "…/vim/neobundles/jedi/jedi/jedi/evaluate/finder.py", line 323, in _remove_statements
        types += evaluator.eval_statement(stmt, seek_name=name)
      File "…/vim/neobundles/jedi/jedi/jedi/evaluate/cache.py", line 41, in wrapper
        rv = function(obj, *args, **kwargs)
      File "…/vim/neobundles/jedi/jedi/jedi/evaluate/recursion.py", line 23, in run
        result = func(evaluator, stmt, *args, **kwargs)
      File "…/vim/neobundles/jedi/jedi/jedi/debug.py", line 52, in wrapper
        result = func(*args, **kwargs)
      File "…/vim/neobundles/jedi/jedi/jedi/evaluate/__init__.py", line 135, in eval_statement
        types = self.eval_element(stmt.get_rhs())
      File "…/vim/neobundles/jedi/jedi/jedi/evaluate/cache.py", line 41, in wrapper
        rv = function(obj, *args, **kwargs)
      File "…/vim/neobundles/jedi/jedi/jedi/evaluate/__init__.py", line 183, in eval_element
        types = self._eval_atom(element.children[0])
      File "…/vim/neobundles/jedi/jedi/jedi/evaluate/__init__.py", line 230, in _eval_atom
        return self.find_types(scope, atom, stmt.start_pos, search_global=True)
      File "…/vim/neobundles/jedi/jedi/jedi/evaluate/__init__.py", line 120, in find_types
        return f.find(scopes, search_global)
      File "…/vim/neobundles/jedi/jedi/jedi/debug.py", line 52, in wrapper
        result = func(*args, **kwargs)
      File "…/vim/neobundles/jedi/jedi/jedi/evaluate/finder.py", line 87, in find
        types = self._names_to_types(names, search_global)
      File "…/vim/neobundles/jedi/jedi/jedi/evaluate/finder.py", line 233, in _names_to_types
        new_types = _name_to_types(self._evaluator, name, self.scope)
      File "…/vim/neobundles/jedi/jedi/jedi/evaluate/cache.py", line 41, in wrapper
        rv = function(obj, *args, **kwargs)
      File "…/vim/neobundles/jedi/jedi/jedi/evaluate/finder.py", line 282, in _name_to_types
        types += imports.ImportWrapper(evaluator, name).follow()
      File "…/vim/neobundles/jedi/jedi/jedi/evaluate/cache.py", line 41, in wrapper
        rv = function(obj, *args, **kwargs)
      File "…/vim/neobundles/jedi/jedi/jedi/evaluate/imports.py", line 94, in follow
        types = importer.follow()
      File "…/vim/neobundles/jedi/jedi/jedi/evaluate/cache.py", line 41, in wrapper
        rv = function(obj, *args, **kwargs)
      File "…/vim/neobundles/jedi/jedi/jedi/evaluate/imports.py", line 252, in follow
        return self._do_import(self.import_path, self.sys_path_with_modifications())
      File "…/vim/neobundles/jedi/jedi/jedi/evaluate/imports.py", line 327, in _do_import
        find_module(import_parts[-1])
      File "…/vim/neobundles/jedi/jedi/jedi/_compatibility.py", line 28, in find_module_py33
        raise ImportError("Originally ValueError: " + e.message)
    AttributeError: 'ValueError' object has no attribute 'message'
