### PR TITLE
find_module_py33: use str(e) with ValueError

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -138,10 +138,9 @@ understand ``AttributeError`` and other code issues.
 Refactoring
 -----------
 
-Jedi would in theory support refactoring, but we have never publicized it,
-because it's not production ready. If you're interested in helping out here,
-let me know. With the latest parser changes, it should be very easy to actually
-make it work.
+Jedi's parser would support refactoring, but there's no API to use it right
+now.  If you're interested in helping out here, let me know. With the latest
+parser changes, it should be very easy to actually make it work.
 
 
 Development


### PR DESCRIPTION
ValueError has no message attribute.

Fixes https://github.com/davidhalter/jedi/issues/584