### PR TITLE
Function return type in completion results

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -33,5 +33,6 @@ Savor d'Isavano (@KenetJervet) <newelevenken@163.com>
 Phillip Berndt (@phillipberndt) <phillip.berndt@gmail.com>
 Ian Lee (@IanLee1521) <IanLee1521@gmail.com>
 Farkhad Khatamov (@hatamov) <comsgn@gmail.com>
+Elad Alfassa (@elad661) <elad@fedoraproject.org>
 
 Note: (@user) means a github user name.

--- a/jedi/api/classes.py
+++ b/jedi/api/classes.py
@@ -308,6 +308,17 @@ class BaseDefinition(object):
 
         return '.'.join(path if path[0] else path[1:])
 
+    @property
+    def return_type(self):
+        if self.type != 'function':
+            raise AttributeError()
+        execute_result = self._evaluator.execute(self._definition)
+        ret = []
+        for r in execute_result:
+            if r.name is not None:
+                ret.append(Definition(self._evaluator, r.name))
+        return ret
+
     def goto_assignments(self):
         defs = self._evaluator.goto(self._name)
         return [Definition(self._evaluator, d) for d in defs]

--- a/test/test_api/test_call_signatures.py
+++ b/test/test_api/test_call_signatures.py
@@ -264,7 +264,7 @@ def test_signature_is_definition():
     # Now compare all the attributes that a CallSignature must also have.
     for attr_name in dir(definition):
         dont_scan = ['defined_names', 'line_nr', 'start_pos', 'documentation',
-                     'doc', 'parent', 'goto_assignments']
+                     'doc', 'parent', 'goto_assignments', 'return_type']
         if attr_name.startswith('_') or attr_name in dont_scan:
             continue
         attribute = getattr(definition, attr_name)


### PR DESCRIPTION
Hi!

For GNOME Builder, we want to have the completion suggestion list show the return value type of each function. Right now, jedi doesn't export this information in its `Completion` class. 

Would it be possible for you to add this as an attribute to the class? Jedi can already parse docstrings and such quite well to guess the return types of functions, so it'd be really convenient (and probably better for performance) if jedi would provide this information as an attribute of the `Completion` class.

btw, feel free to add GNOME Builder to the "jedi users" section of your README file :)