### PR TITLE
initial poc pep-0484 type hints

### DIFF
--- a/jedi/evaluate/finder.py
+++ b/jedi/evaluate/finder.py
@@ -22,6 +22,7 @@ from jedi.evaluate import representation as er
 from jedi.evaluate import dynamic
 from jedi.evaluate import compiled
 from jedi.evaluate import docstrings
+from jedi.evaluate import pep0484
 from jedi.evaluate import iterable
 from jedi.evaluate import imports
 from jedi.evaluate import analysis
@@ -354,6 +355,11 @@ def _eval_param(evaluator, param, scope):
     if isinstance(func, er.InstanceElement) \
             and func.instance.is_generated and str(func.name) == '__init__':
         param = func.var.params[param.position_nr]
+
+    # Add pep0484 type hints
+    pep0484_hints = pep0484.follow_param(evaluator, param)
+    if pep0484_hints:
+        return pep0484_hints
 
     # Add docstring knowledge.
     doc_params = docstrings.follow_param(evaluator, param)

--- a/jedi/evaluate/pep0484.py
+++ b/jedi/evaluate/pep0484.py
@@ -1,0 +1,34 @@
+"""
+PEP 0484 ( https://www.python.org/dev/peps/pep-0484/ ) describes type hints
+through function annotations. There is a strong suggestion in this document
+that only the type of type hinting defined in PEP0484 should be allowed
+as annotations in future python versions.
+
+The (initial / probably incomplete) implementation todo list for pep-0484:
+v Function parameter annotations with builtin/custom type classes
+x Function returntype annotations with builtin/custom type classes
+x Function parameter annotations with strings (forward reference)
+x Function return type annotations with strings (forward reference)
+x Local variable type hints
+x Assigned types: `Url = str\ndef get(url:Url) -> str:`
+x Type hints in `with` statements
+x Stub files support
+"""
+
+from itertools import chain
+
+from jedi.evaluate.cache import memoize_default
+
+
+@memoize_default(None, evaluator_is_first_arg=True)
+def follow_param(evaluator, param):
+    # annotation is in param.children[0] if present
+    # either this firstchild is a Name (if no annotation is present) or a Node
+    if hasattr(param.children[0], "children"):
+        assert len(param.children[0].children) == 3 and \
+            param.children[0].children[1] == ":"
+        definitions = evaluator.eval_element(param.children[0].children[2])
+        return list(chain.from_iterable(
+            evaluator.execute(d) for d in definitions))
+    else:
+        return []

--- a/test/completion/pep0484.py
+++ b/test/completion/pep0484.py
@@ -1,0 +1,14 @@
+""" Pep-0484 type hinting """
+
+# -----------------
+# sphinx style
+# -----------------
+def typehints(a, b: str, c: int, d:int = 4):
+    #? 
+    a
+    #? str()
+    b
+    #? int()
+    c
+    #? int()
+    d


### PR DESCRIPTION
I'm taking a swipe at #170 , and this is just to see if I'm on the right track. jedi/evaluate/pep0484.py contains a checklist with functionality that needs to be implemented on this end (I believe that the first 4 or 5 should be relatively straight-forward to implement, maybe even all with exception of the stub files, especially if they live in a different directory). Then in addition, jedi needs to understand all the subtleties of the typing module, but that's another chapter. Even the current very small change would already fix 50% of the times that I don't get completions in my current project.

Things that I'd like some feedback on (although feel free to shoot at other things as well):
- I'm currently getting the annotations from the parsed code. Alternatively one could ask the python interpreter and use the `.__annotations__`. Which is preferred?
- My `if` and `assert` statements to look for annotations seems to hold in all the tests (in python 3.4). Are the assumptions there correct? Should I perhaps use some less-defensive programming style, to allow for future python-syntax additions?
- I can't get tox to run, so only ran the tests in python 3.4, but I'm pretty sure the test will fail in 2.x because of the syntax. How do I guard the tests such that they only run in >=3.2 ?
- Right now I have annotations take precedence over docstring in case they are present. Is this the way to go, or should we perhaps merge them?
- PEP 0484 supports decorators for switching off type hinting in some modules/functions. For now I didn't include them (even on the todo list) since worst case one will just get wrong completions, right? Or should we allow for them?