### PR TITLE
(Initial) support for pep0484 annotation type hints

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -34,5 +34,6 @@ Phillip Berndt (@phillipberndt) <phillip.berndt@gmail.com>
 Ian Lee (@IanLee1521) <IanLee1521@gmail.com>
 Farkhad Khatamov (@hatamov) <comsgn@gmail.com>
 Kevin Kelley (@kelleyk) <kelleyk@kelleyk.net>
+Reinoud Elhorst (@reinhrst)
 
 Note: (@user) means a github user name.

--- a/jedi/evaluate/finder.py
+++ b/jedi/evaluate/finder.py
@@ -388,15 +388,11 @@ def _eval_param(evaluator, param, scope):
             and func.instance.is_generated and str(func.name) == '__init__':
         param = func.var.params[param.position_nr]
 
-    # Add pep0484 type hints
+    # Add pep0484 and docstring knowledge.
     pep0484_hints = pep0484.follow_param(evaluator, param)
-    if pep0484_hints:
-        return pep0484_hints
-
-    # Add docstring knowledge.
     doc_params = docstrings.follow_param(evaluator, param)
-    if doc_params:
-        return doc_params
+    if pep0484_hints or doc_params:
+        return list(set(pep0484_hints) | set(doc_params))
 
     if isinstance(param, ExecutedParam):
         return res_new | param.eval(evaluator)

--- a/jedi/evaluate/finder.py
+++ b/jedi/evaluate/finder.py
@@ -23,6 +23,7 @@ from jedi.evaluate import representation as er
 from jedi.evaluate import dynamic
 from jedi.evaluate import compiled
 from jedi.evaluate import docstrings
+from jedi.evaluate import pep0484
 from jedi.evaluate import iterable
 from jedi.evaluate import imports
 from jedi.evaluate import analysis
@@ -386,6 +387,11 @@ def _eval_param(evaluator, param, scope):
     if isinstance(func, er.InstanceElement) \
             and func.instance.is_generated and str(func.name) == '__init__':
         param = func.var.params[param.position_nr]
+
+    # Add pep0484 type hints
+    pep0484_hints = pep0484.follow_param(evaluator, param)
+    if pep0484_hints:
+        return pep0484_hints
 
     # Add docstring knowledge.
     doc_params = docstrings.follow_param(evaluator, param)

--- a/jedi/evaluate/pep0484.py
+++ b/jedi/evaluate/pep0484.py
@@ -21,12 +21,22 @@ from itertools import chain
 from jedi.evaluate.cache import memoize_default
 
 
-@memoize_default(None, evaluator_is_first_arg=True)
-def follow_param(evaluator, param):
-    annotation = param.annotation()
-    if annotation:
+def _evaluate_for_annotation(evaluator, annotation):
+    if annotation is not None:
         definitions = evaluator.eval_element(annotation)
         return list(chain.from_iterable(
             evaluator.execute(d) for d in definitions))
     else:
         return []
+
+
+@memoize_default(None, evaluator_is_first_arg=True)
+def follow_param(evaluator, param):
+    annotation = param.annotation()
+    return _evaluate_for_annotation(evaluator, annotation)
+
+
+@memoize_default(None, evaluator_is_first_arg=True)
+def find_return_types(evaluator, func):
+    annotation = func.py__annotations__().get("return", None)
+    return _evaluate_for_annotation(evaluator, annotation)

--- a/jedi/evaluate/pep0484.py
+++ b/jedi/evaluate/pep0484.py
@@ -29,7 +29,10 @@ def _evaluate_for_annotation(evaluator, annotation):
             if (isinstance(definition, CompiledObject) and
                     isinstance(definition.obj, str)):
                 p = Parser(load_grammar(), definition.obj)
-                element = p.module.children[0].children[0]
+                try:
+                    element = p.module.children[0].children[0]
+                except (AttributeError, IndexError):
+                    continue
                 element.parent = annotation.parent
                 definitions |= evaluator.eval_element(element)
             else:

--- a/jedi/evaluate/pep0484.py
+++ b/jedi/evaluate/pep0484.py
@@ -10,7 +10,7 @@ v Function returntype annotations with builtin/custom type classes
 v Function parameter annotations with strings (forward reference)
 v Function return type annotations with strings (forward reference)
 x Local variable type hints
-x Assigned types: `Url = str\ndef get(url:Url) -> str:`
+v Assigned types: `Url = str\ndef get(url:Url) -> str:`
 x Type hints in `with` statements
 x Stub files support
 x support `@no_type_check` and `@no_type_check_decorator`

--- a/jedi/evaluate/pep0484.py
+++ b/jedi/evaluate/pep0484.py
@@ -7,8 +7,8 @@ as annotations in future python versions.
 The (initial / probably incomplete) implementation todo list for pep-0484:
 v Function parameter annotations with builtin/custom type classes
 v Function returntype annotations with builtin/custom type classes
-x Function parameter annotations with strings (forward reference)
-x Function return type annotations with strings (forward reference)
+v Function parameter annotations with strings (forward reference)
+v Function return type annotations with strings (forward reference)
 x Local variable type hints
 x Assigned types: `Url = str\ndef get(url:Url) -> str:`
 x Type hints in `with` statements

--- a/jedi/evaluate/pep0484.py
+++ b/jedi/evaluate/pep0484.py
@@ -1,0 +1,34 @@
+"""
+PEP 0484 ( https://www.python.org/dev/peps/pep-0484/ ) describes type hints
+through function annotations. There is a strong suggestion in this document
+that only the type of type hinting defined in PEP0484 should be allowed
+as annotations in future python versions.
+
+The (initial / probably incomplete) implementation todo list for pep-0484:
+v Function parameter annotations with builtin/custom type classes
+x Function returntype annotations with builtin/custom type classes
+x Function parameter annotations with strings (forward reference)
+x Function return type annotations with strings (forward reference)
+x Local variable type hints
+x Assigned types: `Url = str\ndef get(url:Url) -> str:`
+x Type hints in `with` statements
+x Stub files support
+"""
+
+from itertools import chain
+
+from jedi.evaluate.cache import memoize_default
+
+
+@memoize_default(None, evaluator_is_first_arg=True)
+def follow_param(evaluator, param):
+    # annotation is in param.children[0] if present
+    # either this firstchild is a Name (if no annotation is present) or a Node
+    if hasattr(param.children[0], "children"):
+        assert len(param.children[0].children) == 3 and \
+            param.children[0].children[1] == ":"
+        definitions = evaluator.eval_element(param.children[0].children[2])
+        return list(chain.from_iterable(
+            evaluator.execute(d) for d in definitions))
+    else:
+        return []

--- a/jedi/evaluate/pep0484.py
+++ b/jedi/evaluate/pep0484.py
@@ -6,7 +6,7 @@ as annotations in future python versions.
 
 The (initial / probably incomplete) implementation todo list for pep-0484:
 v Function parameter annotations with builtin/custom type classes
-x Function returntype annotations with builtin/custom type classes
+v Function returntype annotations with builtin/custom type classes
 x Function parameter annotations with strings (forward reference)
 x Function return type annotations with strings (forward reference)
 x Local variable type hints

--- a/jedi/evaluate/pep0484.py
+++ b/jedi/evaluate/pep0484.py
@@ -13,6 +13,7 @@ x Local variable type hints
 x Assigned types: `Url = str\ndef get(url:Url) -> str:`
 x Type hints in `with` statements
 x Stub files support
+x support `@no_type_check` and `@no_type_check_decorator`
 """
 
 from itertools import chain
@@ -22,12 +23,9 @@ from jedi.evaluate.cache import memoize_default
 
 @memoize_default(None, evaluator_is_first_arg=True)
 def follow_param(evaluator, param):
-    # annotation is in param.children[0] if present
-    # either this firstchild is a Name (if no annotation is present) or a Node
-    if hasattr(param.children[0], "children"):
-        assert len(param.children[0].children) == 3 and \
-            param.children[0].children[1] == ":"
-        definitions = evaluator.eval_element(param.children[0].children[2])
+    annotation = param.annotation()
+    if annotation:
+        definitions = evaluator.eval_element(annotation)
         return list(chain.from_iterable(
             evaluator.execute(d) for d in definitions))
     else:

--- a/jedi/parser/tree.py
+++ b/jedi/parser/tree.py
@@ -879,9 +879,6 @@ class Function(ClassOrFunc):
         return bool(self.yields)
 
     def annotation(self):
-        if self.children[0] == "lambda":
-            # lambda functions have no annotation
-            return None
         try:
             if self.children[3] == "->":
                 return _fix_forward_reference(self.children[4])
@@ -963,6 +960,10 @@ class Lambda(Function):
 
     def is_generator(self):
         return False
+
+    def annotation(self):
+        # lambda functions do not support annotations
+        return None
 
     @property
     def yields(self):

--- a/jedi/parser/tree.py
+++ b/jedi/parser/tree.py
@@ -41,7 +41,6 @@ import textwrap
 from jedi._compatibility import (Python3Method, encoding, is_py3, utf8_repr,
                                  literal_eval, use_metaclass, unicode)
 from jedi import cache
-import ast
 
 
 def is_node(node, *symbol_names):
@@ -51,19 +50,6 @@ def is_node(node, *symbol_names):
         return False
     else:
         return type in symbol_names
-
-
-def _fix_forward_reference(annotation):
-    if isinstance(annotation, String):
-        newannotation = Name(
-            annotation.position_modifier,
-            ast.literal_eval(annotation.value),
-            annotation.start_pos,
-            annotation.prefix)
-        newannotation.parent = annotation.parent
-    else:
-        newannotation = annotation
-    return newannotation
 
 
 class PositionModifier(object):
@@ -881,8 +867,9 @@ class Function(ClassOrFunc):
     def annotation(self):
         try:
             if self.children[3] == "->":
-                return _fix_forward_reference(self.children[4])
+                return self.children[4]
             assert self.children[3] == ":"
+            return None
         except IndexError:
             return None
 
@@ -1428,7 +1415,7 @@ class Param(BaseNode):
             assert tfpdef.children[1] == ":"
             assert len(tfpdef.children) == 3
             annotation = tfpdef.children[2]
-            return _fix_forward_reference(annotation)
+            return annotation
         else:
             return None
 

--- a/jedi/parser/tree.py
+++ b/jedi/parser/tree.py
@@ -1403,8 +1403,13 @@ class Param(BaseNode):
             return None
 
     def annotation(self):
-        # Generate from tfpdef.
-        raise NotImplementedError
+        tfpdef = self._tfpdef()
+        if is_node(tfpdef, 'tfpdef'):
+            assert tfpdef.children[1] == ":"
+            assert len(tfpdef.children) == 3
+            return tfpdef.children[2]
+        else:
+            return None
 
     def _tfpdef(self):
         """

--- a/jedi/parser/tree.py
+++ b/jedi/parser/tree.py
@@ -866,7 +866,9 @@ class Function(ClassOrFunc):
 
     def annotation(self):
         try:
-            return self.children[6]  # 6th element: def foo(...) -> bar
+            if self.children[3] == "->":
+                return self.children[4]
+            assert self.children[3] == ":"
         except IndexError:
             return None
 

--- a/test/completion/pep0484.py
+++ b/test/completion/pep0484.py
@@ -133,3 +133,12 @@ def function_forward_reference_dynamic(
 
 def return_str_type():
     return str
+
+
+X = str
+def function_with_assined_class_in_reference(x: X, y: "Y"):
+    #? str()
+    x
+    #? int()
+    y
+Y = int

--- a/test/completion/pep0484.py
+++ b/test/completion/pep0484.py
@@ -110,3 +110,13 @@ class SelfReference:
 
 #? SelfReference()
 SelfReference().test_method()
+
+def function_with_non_pep_0484_annotation(x: "I can put anything here", y: 3 + 3) -> int("42"):
+    # infers int from function call
+    #? int()
+    x
+    # infers str from function call
+    #? str()
+    y
+#?
+function_with_non_pep_0484_annotation(1, "force string")

--- a/test/completion/pep0484.py
+++ b/test/completion/pep0484.py
@@ -1,5 +1,7 @@
 """ Pep-0484 type hinting """
 
+# python >= 3.2
+
 # -----------------
 # simple classes
 # -----------------

--- a/test/completion/pep0484.py
+++ b/test/completion/pep0484.py
@@ -2,17 +2,69 @@
 
 # python >= 3.2
 
-# -----------------
-# simple classes
-# -----------------
+
+class A():
+    pass
 
 
-def typehints(a, b: str, c: int, d: int=4):
-    #?
+def function_parameters(a: A, b, c: str, d: int=4):
+    #? A()
     a
-    #? str()
+    #?
     b
-    #? int()
+    #? str()
     c
     #? int()
     d
+
+
+def return_unspecified():
+    pass
+
+#?
+return_unspecified()
+
+
+def return_none() -> None:
+    """
+    Return type None means the same as no return type as far as jedi
+    is concerned
+    """
+    pass
+
+#?
+return_none()
+
+
+def return_str() -> str:
+    pass
+
+#? str()
+return_str()
+
+
+def return_custom_class() -> A:
+    pass
+
+#? A()
+return_custom_class()
+
+
+def return_annotation_and_docstring() -> str:
+    """
+    :rtype: int
+    """
+    pass
+
+#? str() int()
+return_annotation_and_docstring()
+
+
+def return_annotation_and_docstring_different() -> str:
+    """
+    :rtype: str
+    """
+    pass
+
+#? str()
+return_annotation_and_docstring_different()

--- a/test/completion/pep0484.py
+++ b/test/completion/pep0484.py
@@ -1,10 +1,12 @@
 """ Pep-0484 type hinting """
 
 # -----------------
-# sphinx style
+# simple classes
 # -----------------
-def typehints(a, b: str, c: int, d:int = 4):
-    #? 
+
+
+def typehints(a, b: str, c: int, d: int=4):
+    #?
     a
     #? str()
     b

--- a/test/completion/pep0484.py
+++ b/test/completion/pep0484.py
@@ -1,0 +1,14 @@
+""" Pep-0484 type hinting """
+
+# -----------------
+# sphinx style
+# -----------------
+def typehints(a, b: str, c: int, d:int = 4):
+    #? 
+    a
+    #? str()
+    b
+    #? int()
+    c
+    #? int()
+    d

--- a/test/completion/pep0484.py
+++ b/test/completion/pep0484.py
@@ -120,3 +120,16 @@ def function_with_non_pep_0484_annotation(x: "I can put anything here", y: 3 + 3
     y
 #?
 function_with_non_pep_0484_annotation(1, "force string")
+
+def function_forward_reference_dynamic(
+        x: return_str_type(),
+        y: "return_str_type()") -> None:
+    # technically should not be resolvable since out of scope,
+    # but jedi is not smart enough for that
+    #? str()
+    x
+    #? str()
+    y
+
+def return_str_type():
+    return str

--- a/test/completion/pep0484.py
+++ b/test/completion/pep0484.py
@@ -114,14 +114,23 @@ SelfReference().test_method()
 def function_with_non_pep_0484_annotation(
         x: "I can put anything here",
         xx: "",
-        yy: "\r\n;+*&^564835(---^&*34",
-        y: 3 + 3) -> int("42"):
+        yy: "\r\n\0;+*&^564835(---^&*34",
+        y: 3 + 3,
+        zz: float) -> int("42"):
     # infers int from function call
     #? int()
     x
+    # infers int from function call
+    #? int()
+    xx
+    # infers int from function call
+    #? int()
+    yy
     # infers str from function call
     #? str()
     y
+    #? float()
+    zz
 #?
 function_with_non_pep_0484_annotation(1, 2, 3, "force string")
 

--- a/test/completion/pep0484.py
+++ b/test/completion/pep0484.py
@@ -88,15 +88,25 @@ def annotation_forward_reference(b: "B") -> "B":
 
 #? B()
 annotation_forward_reference(1)
+#? ["test_element"]
+annotation_forward_reference(1).t
 
 class B:
+    test_element = 1
     pass
 
 
 class SelfReference:
-    def test(x: "SelfReference") -> "SelfReference":
+    test_element = 1
+    def test_method(self, x: "SelfReference") -> "SelfReference":
         #? SelfReference()
         x
+        #? ["test_element", "test_method"]
+        self.t
+        #? ["test_element", "test_method"]
+        x.t
+        #? ["test_element", "test_method"]
+        self.test_method(1).t
 
 #? SelfReference()
-SelfReference().test()
+SelfReference().test_method()

--- a/test/completion/pep0484.py
+++ b/test/completion/pep0484.py
@@ -111,7 +111,11 @@ class SelfReference:
 #? SelfReference()
 SelfReference().test_method()
 
-def function_with_non_pep_0484_annotation(x: "I can put anything here", y: 3 + 3) -> int("42"):
+def function_with_non_pep_0484_annotation(
+        x: "I can put anything here",
+        xx: "",
+        yy: "\r\n;+*&^564835(---^&*34",
+        y: 3 + 3) -> int("42"):
     # infers int from function call
     #? int()
     x
@@ -119,7 +123,7 @@ def function_with_non_pep_0484_annotation(x: "I can put anything here", y: 3 + 3
     #? str()
     y
 #?
-function_with_non_pep_0484_annotation(1, "force string")
+function_with_non_pep_0484_annotation(1, 2, 3, "force string")
 
 def function_forward_reference_dynamic(
         x: return_str_type(),

--- a/test/completion/pep0484.py
+++ b/test/completion/pep0484.py
@@ -155,3 +155,7 @@ def function_with_assined_class_in_reference(x: X, y: "Y"):
     #? int()
     y
 Y = int
+
+def just_because_we_can(x: "flo" + "at"):
+    #? float()
+    x

--- a/test/completion/pep0484.py
+++ b/test/completion/pep0484.py
@@ -68,3 +68,23 @@ def return_annotation_and_docstring_different() -> str:
 
 #? str()
 return_annotation_and_docstring_different()
+
+
+def annotation_forward_reference(b: "B") -> "B":
+    #? B()
+    b
+
+#? B()
+annotation_forward_reference(1)
+
+class B:
+    pass
+
+
+class SelfReference:
+    def test(x: "SelfReference") -> "SelfReference":
+        #? SelfReference()
+        x
+
+#? SelfReference()
+SelfReference().test()

--- a/test/completion/pep0484.py
+++ b/test/completion/pep0484.py
@@ -7,7 +7,13 @@ class A():
     pass
 
 
-def function_parameters(a: A, b, c: str, d: int=4):
+def function_parameters(a: A, b, c: str, d: int, e: str, f: str, g: int=4):
+    """
+    :param e: if docstring and annotation agree, only one should be returned
+    :type e: str
+    :param f: if docstring and annotation disagree, both should be returned
+    :type f: int
+    """
     #? A()
     a
     #?
@@ -16,6 +22,12 @@ def function_parameters(a: A, b, c: str, d: int=4):
     c
     #? int()
     d
+    #? str()
+    e
+    #? int() str()
+    f
+    # int()
+    g
 
 
 def return_unspecified():

--- a/test/test_api/test_api.py
+++ b/test/test_api/test_api.py
@@ -9,13 +9,6 @@ from jedi._compatibility import is_py3
 from pytest import raises
 
 
-def _clear_last_exception_fields_in_sys():
-    import sys
-    sys.last_type = None
-    sys.last_value = None
-    sys.last_traceback = None
-
-
 def test_preload_modules():
     def check_loaded(*modules):
         # +1 for None module (currently used)
@@ -27,7 +20,6 @@ def test_preload_modules():
     temp_cache, cache.parser_cache = cache.parser_cache, {}
     parser_cache = cache.parser_cache
 
-    _clear_last_exception_fields_in_sys()
     api.preload_module('sys')
     check_loaded()  # compiled (c_builtin) modules shouldn't be in the cache.
     api.preload_module('json', 'token')

--- a/test/test_api/test_api.py
+++ b/test/test_api/test_api.py
@@ -9,6 +9,13 @@ from jedi._compatibility import is_py3
 from pytest import raises
 
 
+def _clear_last_exception_fields_in_sys():
+    import sys
+    sys.last_type = None
+    sys.last_value = None
+    sys.last_traceback = None
+
+
 def test_preload_modules():
     def check_loaded(*modules):
         # +1 for None module (currently used)
@@ -20,6 +27,7 @@ def test_preload_modules():
     temp_cache, cache.parser_cache = cache.parser_cache, {}
     parser_cache = cache.parser_cache
 
+    _clear_last_exception_fields_in_sys()
     api.preload_module('sys')
     check_loaded()  # compiled (c_builtin) modules shouldn't be in the cache.
     api.preload_module('json', 'token')

--- a/test/test_evaluate/test_annotations.py
+++ b/test/test_evaluate/test_annotations.py
@@ -8,8 +8,8 @@ import pytest
 def test_simple_annotations():
     """
     Annotations only exist in Python 3.
-    At the moment we ignore them. So they should be parsed and not interfere
-    with anything.
+    If annotations adhere to PEP-0484, we use them (they override inference),
+    else they are parsed but ignored
     """
 
     source = dedent("""\
@@ -27,3 +27,11 @@ def test_simple_annotations():
 
     annot_ret('')""")
     assert [d.name for d in jedi.Script(source, ).goto_definitions()] == ['str']
+
+    source = dedent("""\
+    def annot(a:int):
+        return a
+
+    annot('')""")
+
+    assert [d.name for d in jedi.Script(source, ).goto_definitions()] == ['int']

--- a/test/test_parser/test_parser_tree.py
+++ b/test/test_parser/test_parser_tree.py
@@ -12,10 +12,11 @@ from jedi.parser import tree as pt
 class TestsFunctionAndLambdaParsing(object):
 
     FIXTURES = [
-        ('def my_function(x, y, z):\n    return x + y * z\n', {
+        ('def my_function(x, y, z) -> str:\n    return x + y * z\n', {
             'name': 'my_function',
             'call_sig': 'my_function(x, y, z)',
             'params': ['x', 'y', 'z'],
+            'annotation': "str",
         }),
         ('lambda x, y, z: x + y * z\n', {
             'name': '<lambda>',
@@ -55,7 +56,11 @@ class TestsFunctionAndLambdaParsing(object):
             assert not node.yields
 
     def test_annotation(self, node, expected):
-        assert node.annotation() is expected.get('annotation', None)
+        expected_annotation = expected.get('annotation', None)
+        if expected_annotation is None:
+            assert node.annotation() is None
+        else:
+            assert node.annotation().value == expected_annotation
 
     def test_get_call_signature(self, node, expected):
         assert node.get_call_signature() == expected['call_sig']


### PR DESCRIPTION
Per request PR to linter branch for #170 .

Handled the comments on https://github.com/davidhalter/jedi/pull/659 , new/more comments are always welcome!

It should now recognise simple function parameter and return type annotations (this means: single built in or custom classes, including forward referencing).