### PR TITLE
Update API doc for completions

### DIFF
--- a/docs/docs/plugin-api.rst
+++ b/docs/docs/plugin-api.rst
@@ -47,14 +47,14 @@ Completions:
    >>> script = jedi.Script(source, 1, 19, '')
    >>> script
    <jedi.api.Script object at 0x2121b10>
-   >>> completions = script.complete()
+   >>> completions = script.completions()
    >>> completions
    [<Completion: load>, <Completion: loads>]
    >>> completions[1]
    <Completion: loads>
    >>> completions[1].complete
    'oads'
-   >>> completions[1].word
+   >>> completions[1].name
    'loads'
 
 Definitions / Goto:


### PR DESCRIPTION
At least in jedi version 0.9.0 the API seems to change to:
 * complete method is now completions
 * words attribute is now name

Example:
```
(venv)reingart@S55t-B:~$ python
Python 2.7.6 (default, Jun 22 2015, 17:58:13) [GCC 4.8.2] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import jedi
>>> jedi.__version__
'0.9.0'
>>> source = '''import json; json.l'''
>>> script = jedi.Script(source, 1, 19, '')
>>> script
<Script: ''>
>>> completions = script.completions()
>>> completions
[<Completion: load>, <Completion: loads>]
>>> completions[1].complete
'oads'
>>> completions[1].name
u'loads'
>>> 
```