### PR TITLE
Fix AttributeError: 'NoneType' object has no attribute 'names_dict'

### DIFF
--- a/jedi/evaluate/imports.py
+++ b/jedi/evaluate/imports.py
@@ -271,9 +271,11 @@ class Importer(object):
 
         module_name = '.'.join(import_parts)
         try:
-            return [self._evaluator.modules[module_name]]
+            module = self._evaluator.modules[module_name]
         except KeyError:
             pass
+        else:
+            return [module] if module else []
 
         if len(import_path) > 1:
             # This is a recursive way of importing that works great with

--- a/jedi/evaluate/imports.py
+++ b/jedi/evaluate/imports.py
@@ -347,7 +347,7 @@ class Importer(object):
             module = _load_module(self._evaluator, module_path, source, sys_path)
 
         self._evaluator.modules[module_name] = module
-        return [module]
+        return [module] if module else []
 
     def _generate_name(self, name):
         return helpers.FakeName(name, parent=self.module)


### PR DESCRIPTION
`Importer._do_import` should not return `[None]`, which is does for
`import_path`=(<Name: _decimal@3,9>,).

    Traceback (most recent call last):
      File "…/vim/neobundles/jedi/jedi_vim.py", line 189, in completions
        menu=PythonToVimStr(c.description),
      File "…/vim/neobundles/jedi/jedi/jedi/api/classes.py", line 425, in description
        t = self.type
      File "…/vim/neobundles/jedi/jedi/jedi/api/classes.py", line 470, in type
        followed = self.follow_definition()
      File "…/vim/neobundles/jedi/jedi/jedi/evaluate/cache.py", line 41, in wrapper
        rv = function(obj, *args, **kwargs)
      File "…/vim/neobundles/jedi/jedi/jedi/api/classes.py", line 498, in follow_definition
        defs = self._follow_statements_imports()
      File "…/vim/neobundles/jedi/jedi/jedi/evaluate/cache.py", line 41, in wrapper
        rv = function(obj, *args, **kwargs)
      File "…/vim/neobundles/jedi/jedi/jedi/api/classes.py", line 485, in _follow_statements_imports
        return i.follow()
      File "…/vim/neobundles/jedi/jedi/jedi/evaluate/cache.py", line 41, in wrapper
        rv = function(obj, *args, **kwargs)
      File "…/vim/neobundles/jedi/jedi/jedi/evaluate/imports.py", line 103, in follow
        for t in types))
      File "…/vim/neobundles/jedi/jedi/jedi/evaluate/imports.py", line 103, in <genexpr>
        for t in types))
      File "…/vim/neobundles/jedi/jedi/jedi/evaluate/__init__.py", line 120, in find_types
        return f.find(scopes, search_global)
      File "…/vim/neobundles/jedi/jedi/jedi/debug.py", line 52, in wrapper
        result = func(*args, **kwargs)
      File "…/vim/neobundles/jedi/jedi/jedi/evaluate/finder.py", line 86, in find
        names = self.filter_name(scopes)
      File "…/vim/neobundles/jedi/jedi/jedi/evaluate/finder.py", line 176, in filter_name
        for names_dict, position in names_dicts:
      File "…/vim/neobundles/jedi/jedi/jedi/evaluate/finder.py", line 109, in <genexpr>
        return ((n, None) for n in self.scope.names_dicts(search_global))
      File "…/vim/neobundles/jedi/jedi/jedi/evaluate/representation.py", line 720, in names_dicts
        yield star_module.names_dict
    AttributeError: 'NoneType' object has no attribute 'names_dict'

The returend `str(modules)` is the following in `star_imports`:

    [None, <ModuleWrapper: <fast.FastModule: _pydecimal@16-6381>>]