### PR TITLE
Read function annotations in python3

### DIFF
--- a/jedi/parser/grammar3.4.txt
+++ b/jedi/parser/grammar3.4.txt
@@ -27,7 +27,8 @@ parameters: '(' [typedargslist] ')'
 typedargslist: (tfpdef ['=' test] (',' tfpdef ['=' test])* [','
        ['*' [tfpdef] (',' tfpdef ['=' test])* [',' '**' tfpdef] | '**' tfpdef]]
      |  '*' [tfpdef] (',' tfpdef ['=' test])* [',' '**' tfpdef] | '**' tfpdef)
-tfpdef: NAME [':' test]
+tname: NAME [':' test]
+tfpdef: tname
 varargslist: (vfpdef ['=' test] (',' vfpdef ['=' test])* [','
        ['*' [vfpdef] (',' vfpdef ['=' test])* [',' '**' vfpdef] | '**' vfpdef]]
      |  '*' [vfpdef] (',' vfpdef ['=' test])* [',' '**' vfpdef] | '**' vfpdef)


### PR DESCRIPTION
Function annotations are not read in python3 environment.

When run the below code with python2, it shows lots of Completion objects, but with python3, no completions are shown. This PR fixes this.

```py
from jedi import Script

src = 'def a(i:int):\n    i.'
s = Script(src, 2, 6)
print(s.completions())
```

I have added `tname` in grammer for python3, and `tfpdef` is now juast an alias to it.
Although renaming all tfpdef to tname might be better, it makes differences between py2 and py3 grammer files bigger.