### PR TITLE
Add GNOME Builder to README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,6 +41,7 @@ Jedi can currently be used with the following editors:
   <https://projects.kde.org/projects/kde/applications/kate/repository/show?rev=KDE%2F4.13>`_]
 - Atom_ (autocomplete-python_)
 - SourceLair_
+- `GNOME Builder`_ (with support for GObject Introspection)
 
 And it powers the following projects:
 
@@ -191,3 +192,4 @@ For more detailed information visit the `testing documentation
 .. _Atom: https://atom.io/
 .. _autocomplete-python: https://atom.io/packages/autocomplete-python
 .. _SourceLair: https://www.sourcelair.com
+.. _GNOME Builder: https://wiki.gnome.org/Apps/Builder

--- a/docs/docs/usage.rst
+++ b/docs/docs/usage.rst
@@ -55,6 +55,12 @@ SourceLair:
 
 - SourceLair_
 
+GNOME Builder:
+
+- `GNOME Builder`_ `supports it natively
+  <https://git.gnome.org/browse/gnome-builder/tree/plugins/jedi>`__,
+  and is enabled by default.
+
 
 .. _other-software:
 
@@ -96,3 +102,4 @@ Using a custom ``$HOME/.pythonrc.py``
 .. _kate: http://kate-editor.org/
 .. _autocomplete-python: https://atom.io/packages/autocomplete-python
 .. _SourceLair: https://www.sourcelair.com
+.. _GNOME Builder: https://wiki.gnome.org/Apps/Builder/


### PR DESCRIPTION
Add `GNOME Builder` to README.rst list of supported editors.
Support is provided out of the box as long as python3-jedi is installed.
Additionally, Builder's implementation includes support for GObject
Introspection and Gtk.