### PR TITLE
Enabled python 3.5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,9 @@ matrix:
         - env: TOXENV=cov
         - env: TOXENV=sith
         - env: TOXENV=pypy
+python: 3.5
 install:
-    - pip install --quiet --use-mirrors tox
+    - pip install --quiet tox 'virtualenv<14.0.0' 'pip<8.0.0'
 script:
     - tox
 after_script:
@@ -24,3 +25,4 @@ after_script:
       pip install --quiet --use-mirrors coveralls;
       coveralls;
       fi
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ env:
     - TOXENV=py32
     - TOXENV=py33
     - TOXENV=py34
+    - TOXENV=py35
     - TOXENV=pypy
     - TOXENV=cov
     - TOXENV=sith

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py32, py33, py34
+envlist = py26, py27, py32, py33, py34, py35
 [testenv]
 deps =
     pytest>=2.3.5

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,11 @@ commands =
 deps =
     unittest2
     {[testenv]deps}
+[testenv:py32]
+deps =
+    pip<8.0.0
+    virtualenv<14.0.0
+    {[testenv]deps}
 [testenv:cov]
 deps =
     coverage


### PR DESCRIPTION
The tests weren't testing Python 3.5 yet, now they do :)

I didn't have any other Python 3 available on my system so couldn't use tox otherwise