### PR TITLE
Fix failure with ``module_path``

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,11 @@
 Changelog
 ---------
 
+0.10.0 (unreleased)
++++++++++++++++++++
+
+- Fix failure when ``module_path`` wasn't available in ``jedi.evaluate.imports.Importer._do_import``.
+
 0.9.0 (2015-04-10)
 ++++++++++++++++++
 

--- a/jedi/evaluate/imports.py
+++ b/jedi/evaluate/imports.py
@@ -275,6 +275,7 @@ class Importer(object):
         except KeyError:
             pass
 
+        module_path = None
         if len(import_path) > 1:
             # This is a recursive way of importing that works great with
             # the module cache.
@@ -312,7 +313,7 @@ class Importer(object):
                             find_module(import_parts[-1], [path])
                         break
                     except ImportError:
-                        module_path = None
+                        pass
                 if module_path is None:
                     _add_error(self._evaluator, import_path[-1])
                     return []


### PR DESCRIPTION
Fix failure when ``module_path`` wasn't available in ``jedi.evaluate.imports.Importer._do_import``.