### PR TITLE
Encoding isn't set for imported modules

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -34,5 +34,6 @@ Phillip Berndt (@phillipberndt) <phillip.berndt@gmail.com>
 Ian Lee (@IanLee1521) <IanLee1521@gmail.com>
 Farkhad Khatamov (@hatamov) <comsgn@gmail.com>
 Kevin Kelley (@kelleyk) <kelleyk@kelleyk.net>
+Dmytro Sadovnychyi (@sadovnychyi) <jedi@dmit.ro>
 
 Note: (@user) means a github user name.

--- a/jedi/common.py
+++ b/jedi/common.py
@@ -134,7 +134,7 @@ def source_to_unicode(source, encoding=None):
             return possible_encoding.group(1)
         else:
             # the default if nothing else has been set -> PEP 263
-            return encoding if encoding is not None else 'iso-8859-1'
+            return encoding if encoding is not None else 'utf-8'
 
     if isinstance(source, unicode):
         # only cast str/bytes


### PR DESCRIPTION
https://github.com/davidhalter/jedi/blob/master/jedi/evaluate/imports.py#L445

Here the forced encoding isn't applied and therefore we cannot correctly recognize non-ascii doc strings in imported modules. 

Can we pass the value presented in Script's `encoding` argument somehow? Basically every call to source_to_unicode should be with default set to argument passed in Script.

https://github.com/sadovnychyi/autocomplete-python/issues/210