### PR TITLE
allow access to jedi.evaluate.representation.Instance.names_dict

### DIFF
--- a/jedi/evaluate/representation.py
+++ b/jedi/evaluate/representation.py
@@ -244,7 +244,7 @@ class Instance(use_metaclass(CachedMetaClass, Executed)):
 
     def __getattr__(self, name):
         if name not in ['start_pos', 'end_pos', 'get_imports', 'type',
-                        'doc', 'raw_doc']:
+                        'doc', 'raw_doc', 'names_dict']:
             raise AttributeError("Instance %s: Don't touch this (%s)!"
                                  % (self, name))
         return getattr(self.base, name)

--- a/test/test_evaluate/test_representation.py
+++ b/test/test_evaluate/test_representation.py
@@ -1,6 +1,6 @@
 from textwrap import dedent
 
-from jedi import Script
+from jedi import Script, names
 
 
 def get_definition_and_evaluator(source):
@@ -34,3 +34,17 @@ def test_class_mro():
     cls, evaluator = get_definition_and_evaluator(s)
     mro = cls.py__mro__()
     assert [str(c.name) for c in mro] == ['X', 'object']
+
+
+def test_instance_defined_names():
+    """
+    At one point, defined_names() would fail for instances
+    """
+    s = """
+    class X(object):
+        def func():
+            pass
+    x = X()
+    """
+    n = names(s)[1].defined_names()
+    assert n[0].name == 'func'


### PR DESCRIPTION
A user is unable to run code like `n = jedi.names("lst = list()")[0].defined_names()` (see https://stackoverflow.com/questions/37686311/python-jedi-how-to-retrieve-methods-of-instances). This seems to be because `jedi.evaluate.representation.Instance.__getattr__()` blocks evaluation of `.names_dict`. This change allows the code to run.
