### PR TITLE
Makes CallSignature.call_signature()

### DIFF
--- a/jedi/api/classes.py
+++ b/jedi/api/classes.py
@@ -717,6 +717,9 @@ class CallSignature(Definition):
         """
         return self._executable.get_parent_until()
 
+    def call_signature(self, max_width):
+        return _Help(self._definition).call_signature(max_width)
+
     def __repr__(self):
         return '<%s: %s index %s>' % (type(self).__name__, self._name,
                                       self.index)
@@ -745,6 +748,12 @@ class _Help(object):
     """
     def __init__(self, definition):
         self._name = definition
+
+    def call_signature(self, max_width):
+        try:
+            return self._name.get_call_signature(max_width)
+        except AttributeError:
+            return ''
 
     def full(self):
         try:

--- a/test/test_api/test_call_signatures.py
+++ b/test/test_api/test_call_signatures.py
@@ -27,7 +27,10 @@ def assert_signature_string(source, line, column, expected_string):
     assert len(signatures) <= 1
 
     if signatures:
-        assert signatures[0].call_signature == expected_string
+        assert signatures[0].call_signature(4000) == expected_string
+    else:
+        assert False, \
+            'There are no signatures, but `%s` expected.' % expected_string
 
 
 class TestCallSignatures(TestCase):
@@ -231,9 +234,11 @@ class TestCallSignatures(TestCase):
     def test_call_signature_string(self):
         source = dedent('''
         def foo(par1, par2=None, par3=['test']):
-            return''')
+            return
+        foo()
+        ''')
         
-        assert_signature_string(source, 1, 0, "foo(par1, par2=None, par3=['test'])")
+        assert_signature_string(source, 4, len('foo('), "foo(par1, par2=None, par3=['test'])")
 
 
 class TestParams(TestCase):

--- a/test/test_api/test_call_signatures.py
+++ b/test/test_api/test_call_signatures.py
@@ -21,6 +21,15 @@ def assert_signature(source, expected_name, expected_index=0, line=None, column=
         return signatures[0]
 
 
+def assert_signature_string(source, line, column, expected_string):
+    signatures = Script(source, line, column).call_signatures()
+
+    assert len(signatures) <= 1
+
+    if signatures:
+        assert signatures[0].call_signature == expected_string
+
+
 class TestCallSignatures(TestCase):
     def _run_simple(self, source, name, index=0, column=None, line=1):
         assert_signature(source, name, index, line, column)
@@ -218,6 +227,13 @@ class TestCallSignatures(TestCase):
             return '.'.join()''')
 
         assert_signature(source, 'join', 0, column=len("    return '.'.join("))
+        
+    def test_call_signature_string(self):
+        source = dedent('''
+        def foo(par1, par2=None, par3=['test']):
+            return''')
+        
+        assert_signature_string(source, 1, 0, "foo(par1, par2=None, par3=['test'])")
 
 
 class TestParams(TestCase):


### PR DESCRIPTION
It is same result as in docstring, ie method .doc, ie property. So it is with "self" (for methods) -i dont like it, but no other way, easy.
