### PR TITLE
sometime namespace packages got no parents

### DIFF
--- a/jedi/evaluate/imports.py
+++ b/jedi/evaluate/imports.py
@@ -457,6 +457,8 @@ def _load_module(evaluator, path=None, source=None, sys_path=None, parent_module
     cached = load_parser(path)
     module = load(source) if cached is None else cached.module
     module = evaluator.wrap(module)
+    if not module._parent_module:
+        module._parent_module = parent_module
     return module
 
 


### PR DESCRIPTION
Hi,

I got a strange situation with nested namespace packages. say I have the following modules:
- ns1.ns2.mod1
- ns1.ns2.mod2 in another path

The first time I do a <leader>d on ns1.ns2.mod1 it works.
The second time I do a <leader>d on ns1.ns2.mod2 it fails because the ns2 has no parent_module.

This PR resolves this although I have no real understanding on the root cause. 

refs #122 
