### PR TITLE
fixed MappingProxyType import error in PyPy 2.4.0 running Python 3.2.5

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -40,6 +40,7 @@ Guido van Rossum (@gvanrossum) <guido@python.org>
 Dmytro Sadovnychyi (@sadovnychyi) <jedi@dmit.ro>
 Cristi Burcă (@scribu)
 bstaint (@bstaint)
+Oscar Campos (@damnwidget)
 
 
 Note: (@user) means a github user name.

--- a/jedi/_compatibility.py
+++ b/jedi/_compatibility.py
@@ -17,6 +17,7 @@ is_py33 = is_py3 and sys.version_info.minor >= 3
 is_py34 = is_py3 and sys.version_info.minor >= 4
 is_py35 = is_py3 and sys.version_info.minor >= 5
 is_py26 = not is_py3 and sys.version_info[1] < 7
+is_pypy32 = is_py3 and not is_py33 and '__pypy__' in sys.modules
 
 
 class DummyFile(object):

--- a/jedi/evaluate/compiled/fake.py
+++ b/jedi/evaluate/compiled/fake.py
@@ -8,7 +8,7 @@ import os
 import inspect
 import types
 
-from jedi._compatibility import is_py3, builtins, unicode, is_py34
+from jedi._compatibility import is_py3, builtins, unicode, is_py34, is_pypy32
 from jedi.parser import ParserWithRecovery, load_grammar
 from jedi.parser import tree as pt
 from jedi.evaluate.helpers import FakeName
@@ -35,10 +35,11 @@ NOT_CLASS_TYPES = (
 )
 
 if is_py3:
-    NOT_CLASS_TYPES += (
-        types.MappingProxyType,
-        types.SimpleNamespace
-    )
+    if not is_pypy32:
+        NOT_CLASS_TYPES += (
+            types.MappingProxyType,
+            types.SimpleNamespace
+        )
     if is_py34:
         NOT_CLASS_TYPES += (types.DynamicClassAttribute,)
 


### PR DESCRIPTION
Hi @davidhalter, I am not sure if you are gonna like to merge this PR but I already have this in my fork to fix pypy3 support into anaconda that was broken for distributions that include the PyPy 2.4.0 as single PyPy3 package in the system. 

If you try to import `debug` from `jedi` you get the following error:
```
Python 3.2.5 (b2091e973da69152b3f928bfaabd5d2347e6df46, Mar 04 2016, 07:08:30)
[PyPy 2.4.0 with GCC 5.3.0] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>>> from jedi import debug
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "jedi/__init__.py", line 41, in <module>
    from jedi.api import Script, Interpreter, NotFoundError, set_debug_function
  File "jedi/api/__init__.py", line 25, in <module>
    from jedi.api import classes
  File "jedi/api/classes.py", line 15, in <module>
    from jedi.evaluate.cache import memoize_default, CachedMetaClass
  File "jedi/evaluate/__init__.py", line 69, in <module>
    from jedi.evaluate import representation as er
  File "jedi/evaluate/representation.py", line 48, in <module>
    from jedi.evaluate import compiled
  File "jedi/evaluate/compiled/__init__.py", line 15, in <module>
    from . import fake
  File "jedi/evaluate/compiled/fake.py", line 39, in <module>
    types.MappingProxyType,
AttributeError: 'module' object has no attribute 'MappingProxyType'
>>>>
```
This is due the lack of `MappingProxyType` in Python 3.2 that is not supported anymore but as I already mentioned is the most up to date package available in some distros for pypy3 like Arch for example.

I did not add a `is_py32` variable as it makes no sense as no one will be using py32 for CPython that is why I added it just for PyPy implementations.

All the tests are passing.