### PR TITLE
sys_path: prepend/prefer egg-link files

### DIFF
--- a/jedi/evaluate/sys_path.py
+++ b/jedi/evaluate/sys_path.py
@@ -27,14 +27,13 @@ def get_venv_path(venv):
 def _get_sys_path_with_egglinks(sys_path):
     """Find all paths including those referenced by egg-links.
 
-    Egg-link-referenced directories are inserted into path immediately after
+    Egg-link-referenced directories are inserted into path immediately before
     the directory on which their links were found.  Such directories are not
     taken into consideration by normal import mechanism, but they are traversed
     when doing pkg_resources.require.
     """
     result = []
     for p in sys_path:
-        result.append(p)
         # pkg_resources does not define a specific order for egg-link files
         # using os.listdir to enumerate them, we're sorting them to have
         # reproducible tests.
@@ -47,6 +46,7 @@ def _get_sys_path_with_egglinks(sys_path):
                         # pkg_resources package only interprets the first
                         # non-empty line in egg-link files.
                         break
+        result.append(p)
     return result
 
 

--- a/test/test_evaluate/test_sys_path.py
+++ b/test/test_evaluate/test_sys_path.py
@@ -42,9 +42,9 @@ def test_get_venv_path(venv):
     site_pkgs = (glob(pjoin(venv, 'lib', 'python*', 'site-packages')) +
                  glob(pjoin(venv, 'lib', 'site-packages')))[0]
     ETALON = [
-        site_pkgs,
         pjoin('/path', 'from', 'egg-link'),
         pjoin(site_pkgs, '.', 'relative', 'egg-link', 'path'),
+        site_pkgs,
         pjoin(site_pkgs, 'dir-from-foo-pth'),
     ]
 


### PR DESCRIPTION
With `pip install -e` the generated .egg-link file gets preferred over
any normally installed distribution, and `pip uninstall` will first
remove the egg-link before the normal package.

I am not really confident if this is correct, but it just helped with resolving `src/django-filter/django_filters/filters.py` to the version installed with `pip install -e`.