### PR TITLE
tox: use posargs and test by default for py.test command

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ setenv =
 # tox corrupts __pycache__, solution from here:
     PYTHONDONTWRITEBYTECODE=1
 commands =
-    py.test []
+    py.test {posargs:jedi test}
 [testenv:py26]
 deps =
     unittest2


### PR DESCRIPTION
Otherwise it will collect tests from other dirs also by default.
