### PR TITLE
parser.utils.clear_cache: clear self.__index

### DIFF
--- a/jedi/parser/utils.py
+++ b/jedi/parser/utils.py
@@ -160,7 +160,6 @@ class ParserPickling(object):
                 # 0 means version is not defined (= always delete cache):
                 if data.get('version', 0) != self.version:
                     self.clear_cache()
-                    self.__index = {}
                 else:
                     self.__index = data['index']
         return self.__index
@@ -180,6 +179,7 @@ class ParserPickling(object):
 
     def clear_cache(self):
         shutil.rmtree(self._cache_directory())
+        self.__index = {}
 
     def _get_hashed_path(self, path):
         return self._get_path('%s.pkl' % hashlib.md5(path.encode("utf-8")).hexdigest())


### PR DESCRIPTION
This fixes a potential FileNotFoundError when clearing the cache
manually, using the method from
https://github.com/davidhalter/jedi-vim/pull/625.

Traceback:

```
  File "…/jedi/evaluate/imports.py", line 342, in _do_import
    module = _load_module(self._evaluator, module_path, source, sys_path, parent_module)
  File "…/jedi/evaluate/imports.py", line 457, in _load_module
    cached = load_parser(path)
  File "…/jedi/parser/utils.py", line 72, in load_parser
    return ParserPickling.load_parser(path, p_time)
  File "…/jedi/parser/utils.py", line 126, in load_parser
    with open(self._get_hashed_path(path), 'rb') as f:
FileNotFoundError: [Errno 2] No such file or directory: '…/.cache/jedi/cpython-35/759d60e96c76f41ffd882d9b8d844899.pkl'
```