### PR TITLE
Fix goto_definitions being invoked on a parent class

### DIFF
--- a/jedi/evaluate/__init__.py
+++ b/jedi/evaluate/__init__.py
@@ -446,7 +446,9 @@ class Evaluator(object):
         def_ = name.get_definition()
         is_simple_name = name.parent.type not in ('power', 'trailer')
         if is_simple_name:
-            if name.parent.type in ('file_input', 'classdef', 'funcdef'):
+            if name.parent.type == 'classdef' and name.parent.name == name:
+                return [self.wrap(name.parent)]
+            if name.parent.type in ('file_input', 'funcdef'):
                 return [self.wrap(name.parent)]
             if def_.type == 'expr_stmt' and name in def_.get_defined_names():
                 return self.eval_statement(def_, name)

--- a/test/completion/classes.py
+++ b/test/completion/classes.py
@@ -160,6 +160,7 @@ class Mixin(SuperClass):
     def method_mixin(self):
         return int
 
+#? 20 SuperClass
 class SubClass(SuperClass):
     class_sub = 3
     def __init__(self):


### PR DESCRIPTION
When invoking `goto_definitions` on `RequestFactory` in line 5, it would
jump to `Client` after 27f05de:

``` python
class RequestFactory(object):
    pass

class Client(RequestFactory):
    pass
```

Fixes https://github.com/davidhalter/jedi/issues/761.

@davidhalter 
This needs a test, and I am not sure if this fix is correct and makes sense.
Please advice me where and how to add it.
