### PR TITLE
Added google style docstr support + numpy docstr fixes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ Changelog
 - PEP 484 support (most of the important features of it). Thanks Claude! (@reinhrst)
 - Added ``get_line_code`` to ``Definition`` and ``Completion`` objects.
 - Again a lot of internal changes.
+- Added support for Google docstrings.
 
 0.9.0 (2015-04-10)
 ++++++++++++++++++

--- a/jedi/evaluate/docscrape_google.py
+++ b/jedi/evaluate/docscrape_google.py
@@ -1,4 +1,11 @@
 # -*- coding: utf-8 -*-
+"""
+Handles parsing of information out of google style docstrings
+
+CommaneLine:
+    # Run the doctests
+    tox -e py jedi/evaluate/docscrape_google.py
+"""
 from __future__ import print_function, division, absolute_import
 import re
 import sys
@@ -252,7 +259,7 @@ def split_google_docblocks(docstr):
         ['Todo'],
     ]
     # Map aliased tags to a cannonical name (the first item in the group).
-    tag_aliases = {item: group[0] for group in tag_groups for item in group}
+    tag_aliases = dict([(item, group[0]) for group in tag_groups for item in group])
     tag_pattern = '^' + '(' + '|'.join(tag_aliases.keys()) + '): *$'
 
     group_id = 0

--- a/jedi/evaluate/docscrape_google.py
+++ b/jedi/evaluate/docscrape_google.py
@@ -5,7 +5,7 @@ import sys
 
 
 def parse_google_args(docstr):
-    """
+    r"""
     Generates dictionaries of argument hints based on a google docstring
 
     Args:
@@ -18,8 +18,8 @@ def parse_google_args(docstr):
         >>> from jedi.evaluate.docscrape_google import *  # NOQA
         >>> docstr = parse_google_args.__doc__
         >>> argdict_list = list(parse_google_args(docstr))
-        >>> print(argdict_list)
-        [{'type': 'str', 'name': 'docstr'}]
+        >>> print([sorted(d.items()) for d in argdict_list])
+        [[('name', 'docstr'), ('type', 'str')]]
     """
     blocks = split_google_docblocks(docstr)
     for key, lines in blocks:
@@ -29,7 +29,7 @@ def parse_google_args(docstr):
 
 
 def parse_google_returns(docstr):
-    """
+    r"""
     Generates dictionaries of possible return hints based on a google docstring
 
     Args:
@@ -42,8 +42,8 @@ def parse_google_returns(docstr):
         >>> from jedi.evaluate.docscrape_google import *  # NOQA
         >>> docstr = parse_google_returns.__doc__
         >>> retdict_list = list(parse_google_returns(docstr))
-        >>> print(retdict_list)
-        [{'type': 'dict'}]
+        >>> print([sorted(d.items()) for d in retdict_list])
+        [[('type', 'dict')]]
     """
     blocks = split_google_docblocks(docstr)
     for key, lines in blocks:
@@ -64,22 +64,22 @@ def parse_google_retblock(lines):
         >>> from jedi.evaluate.docscrape_google import *  # NOQA
         >>> # Test various ways that arglines can be written
         >>> line_list = [
-        >>>     '',
-        >>>     'no type, just a description',
-        >>>     'list: a description',
-        >>>     'bool: a description\n    with a newline',
-        >>>     'int or bool: a description',
-        >>>     'threading.Thread: a description',
-        >>>     '(int, str): a tuple of int and str',
-        >>>     'tuple: a tuple of int and str',
-        >>>     'Tuple[int, str]: a tuple of int and str',
-        >>>     # Variations without the colon or a description
-        >>>     'list',
-        >>>     'Tuple[int, str]',
-        >>> ]
+        ...     '',
+        ...     'no type, just a description',
+        ...     'list: a description',
+        ...     'bool: a description\n    with a newline',
+        ...     'int or bool: a description',
+        ...     'threading.Thread: a description',
+        ...     '(int, str): a tuple of int and str',
+        ...     'tuple: a tuple of int and str',
+        ...     'Tuple[int, str]: a tuple of int and str',
+        ...     # Variations without the colon or a description
+        ...     'list',
+        ...     'Tuple[int, str]',
+        ... ]
         >>> lines = '\n'.join(line_list)
         >>> retdict_list = list(parse_google_retblock(lines))
-        >>> print('retdict_list = %s' % (retdict_list),)
+        >>> #print('retdict_list = %s' % (retdict_list),)
         >>> # : only the first of these lines should not parse
         >>> # assert len(retdict_list) == len(line_list) - 2
         >>> # but for now any non-empty line parses

--- a/jedi/evaluate/docscrape_google.py
+++ b/jedi/evaluate/docscrape_google.py
@@ -50,7 +50,7 @@ def parse_google_argblock(lines):
         http://www.sphinx-doc.org/en/stable/ext/example_google.html#example-google
 
     Example:
-        >>> from jedi.evaluate.google_docscrape import *  # NOQA
+        >>> from jedi.evaluate.docscrape_google import *  # NOQA
         >>> # Test various ways that arglines can be written
         >>> line_list = [
         ...     'foo1 (int): a description',
@@ -98,7 +98,7 @@ def split_google_docblocks(docstr):
             tag and the second item is the bock corresponding to that tag.
 
     Example:
-        >>> from jedi.evaluate.google_docscrape import *  # NOQA
+        >>> from jedi.evaluate.docscrape_google import *  # NOQA
         >>> docstr = split_google_docblocks.__doc__
         >>> groups = split_google_docblocks(docstr)
         >>> #print('groups = %s' % (groups,))

--- a/jedi/evaluate/docstrings.py
+++ b/jedi/evaluate/docstrings.py
@@ -327,8 +327,6 @@ def _execute_array_values(evaluator, array):
     """
     Tuples indicate that there's not just one return value, but the listed
     ones.  `(str, int)` means that it returns a tuple with both types.
-
-    array = list(definitions)[0]
     """
     if isinstance(array, Array):
         values = []

--- a/jedi/evaluate/docstrings.py
+++ b/jedi/evaluate/docstrings.py
@@ -65,7 +65,7 @@ else:
         return []
 
 
-from jedi.evaluate.google_docscrape import parse_google_args
+from jedi.evaluate.docscrape_google import parse_google_args
 
 def _search_param_in_googledocstr(docstr, param_str):
     """

--- a/jedi/evaluate/docstrings.py
+++ b/jedi/evaluate/docstrings.py
@@ -260,26 +260,22 @@ def _strip_rst_role(type_str):
 
 def _evaluate_for_statement_string(evaluator, string, module):
     """
-
-    python -m jedi.evaluate.docstrings _evaluate_for_statement_string
-
-    Example:
-        >>> from jedi.evaluate.docstrings import *  # NOQA
-        >>> from jedi.evaluate.docstrings import _search_param_in_docstr
-        >>> from jedi.evaluate.docstrings import _evaluate_for_statement_string
-        >>> from jedi.evaluate.docstrings import _execute_array_values
-        >>> from jedi.evaluate.docstrings import _execute_types_in_stmt
-        >>> from jedi._compatibility import builtins
-        >>> import jedi
-        >>> source = open(jedi.evaluate.docstrings.__file__.replace('.pyc', '.py'), 'r').read()
-        >>> script = jedi.Script(source)
-        >>> evaluator = script._evaluator
-        >>> module = script._get_module()
-        >>> string = 'int'
-        >>> type_list = _evaluate_for_statement_string(evaluator, string, module)
-        >>> assert len(type_list) == 1, 'only one possible type'
-        >>> baseobj_list = [t.base.obj for t in type_list]
-        >>> assert baseobj_list[0] is builtins.int, 'should be int'
+    >>> from jedi.evaluate.docstrings import *  # NOQA
+    >>> from jedi.evaluate.docstrings import _search_param_in_docstr
+    >>> from jedi.evaluate.docstrings import _evaluate_for_statement_string
+    >>> from jedi.evaluate.docstrings import _execute_array_values
+    >>> from jedi.evaluate.docstrings import _execute_types_in_stmt
+    >>> from jedi._compatibility import builtins
+    >>> import jedi
+    >>> source = open(jedi.evaluate.docstrings.__file__.replace('.pyc', '.py'), 'r').read()
+    >>> script = jedi.Script(source)
+    >>> evaluator = script._evaluator
+    >>> module = script._get_module()
+    >>> string = 'int'
+    >>> type_list = _evaluate_for_statement_string(evaluator, string, module)
+    >>> assert len(type_list) == 1, 'only one possible type'
+    >>> baseobj_list = [t.base.obj for t in type_list]
+    >>> assert baseobj_list[0] is builtins.int, 'should be int'
     """
     if string is None:
         return []
@@ -436,15 +432,3 @@ def find_return_types(evaluator, func):
         type_ = _evaluate_for_statement_string(evaluator, type_str, module)
         types.extend(type_)
     return types
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m jedi.evaluate.docstrings
-        python -m jedi.evaluate.docstrings --allexamples
-    """
-    import multiprocessing
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-    ut.doctest_funcs()

--- a/jedi/evaluate/docstrings.py
+++ b/jedi/evaluate/docstrings.py
@@ -120,7 +120,7 @@ def _expand_typestr(p_type):
     """
     Attempts to interpret the possible types
     """
-    # Check if multiple types are specified
+    # Check if alternative types are specified
     if re.search('\\bor\\b', p_type):
         types = [t.strip() for t in p_type.split('or')]
     # Check if type has a set of valid literal values
@@ -157,7 +157,6 @@ def _search_param_in_googledocstr(docstr, param_str):
     found = None
     for garg in docscrape_google.parse_google_args(docstr):
         if garg['name'] == param_str:
-            # TODO: parse multiple / complex / optional types
             typestr = garg['type']
             found = _expand_typestr(typestr)
             break

--- a/jedi/evaluate/docstrings.py
+++ b/jedi/evaluate/docstrings.py
@@ -83,7 +83,7 @@ def _search_param_in_googledocstr(docstr, param_str):
 
 
 def _search_param_in_docstr(docstr, param_str):
-    """
+    r"""
     Search `docstr` for type(-s) of `param_str`.
 
     >>> from jedi.evaluate.docstrings import _search_param_in_docstr

--- a/jedi/evaluate/google_docscrape.py
+++ b/jedi/evaluate/google_docscrape.py
@@ -1,0 +1,234 @@
+import re
+
+
+def parse_google_args(docstr):
+    """
+    Args:
+        docstr (str): a google-style docstring
+
+    Yields:
+        dict: dictionaries of parameter hints
+    """
+    blocks = split_google_docblocks(docstr)
+    for key, lines in blocks:
+        if key == 'Args':
+            for argdict in parse_google_argblock(lines):
+                yield argdict
+
+
+def parse_google_returns(docstr):
+    """
+    Args:
+        docstr (str): a google-style docstring
+
+    Yields:
+        dict: dictionaries of return value hints
+    """
+    blocks = split_google_docblocks(docstr)
+    for key, lines in blocks:
+        if key == 'Returns':
+            for retdict in parse_google_retblock(lines):
+                yield retdict
+
+
+def parse_google_retblock(lines):
+    """
+    Args:
+        lines (str): the unindented lines from an Returns docstring section
+    """
+    raise NotImplementedError
+
+
+def parse_google_argblock(lines):
+    """
+    Args:
+        lines (str): the unindented lines from an Args docstring section
+
+    References:
+        # Not sure which one of these is *the* standard
+        https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html#example-google
+        http://www.sphinx-doc.org/en/stable/ext/example_google.html#example-google
+
+    Example:
+        >>> from jedi.evaluate.docstrings import parse_google_argblock
+        >>> # Test various ways that arglines can be written
+        >>> line_list = [
+        >>>     'foo1 (int): a description',
+        >>>     'foo2: a description\n    with a newline',
+        >>>     'foo3 (int or str): a description',
+        >>>     'foo4 (int or threading.Thread): a description',
+        >>>     #
+        >>>     # this is sphynx-like typing style
+        >>>     'param1 (:obj:`str`, optional): ',
+        >>>     'param2 (:obj:`list` of :obj:`str`):',
+        >>>     #
+        >>>     # the Type[type] syntax is defined by the python typeing module
+        >>>     'attr1 (Optional[int]): Description of `attr1`.',
+        >>>     'attr2 (List[str]): Description of `attr2`.',
+        >>>     'attr3 (Dict[str, str]): Description of `attr3`.',
+        >>> ]
+        >>> lines = '\n'.join(line_list)
+        >>> argdict_list = list(parse_google_argblock(lines))
+        >>> print('argdict_list = %s' % (ut.repr4(argdict_list),))
+        >>> assert len(argdict_list) == len(line_list)
+    """
+    name_pat = r'(?P<name>[A-Za-z_][A-Za-z0-9_]*)'
+    type_pat = r'(?P<type>[^)]*)'
+    # Typing is optional
+    type_part = '(' + '|'.join(['\(' + type_pat + '\)\s*:', '\s*:']) + ')'
+    argline_pat = '^' + name_pat + r'\s*' + type_part
+
+    argdict_list = []
+    for match in re.finditer(argline_pat, lines, flags=re.M):
+        argdict = match.groupdict()
+        type_ = argdict['type']
+        if type_ is not None:
+            pass
+        argdict_list.append(argdict)
+    return argdict_list
+
+
+def split_google_docblocks(docstr):
+    """
+    Args:
+        docstr (str): a docstring
+
+    Returns:
+        list: list of 2-tuples where the first item is a google style docstring
+            tag and the second item is the bock corresponding to that tag.
+
+    Example:
+        >>> from jedi.evaluate.docstrings import *  # NOQA
+        >>> from jedi.evaluate.docstrings import split_google_docblocks
+        >>> docstr = split_google_docblocks.__doc__
+        >>> groups = split_google_docblocks(docstr)
+        >>> result = ('groups = %s' % (ut.repr2(groups),))
+        >>> print(result)
+    """
+    import re
+    import textwrap
+    import collections
+
+    def get_indentation(line_):
+        """ returns number of preceding spaces """
+        return len(line_) - len(line_.lstrip())
+
+    # Parse out initial documentation lines
+    # Then parse out the blocked lines.
+    docstr = textwrap.dedent(docstr)
+    docstr_lines = docstr.split('\n')
+    line_indent = [get_indentation(line) for line in docstr_lines]
+    line_len = [len(line) for line in docstr_lines]
+
+    # The first line may not have the correct indentation if it starts
+    # right after the triple quotes. Adjust it in this case to ensure that
+    # base indent is always 0
+    adjusted = False
+    is_nonzero = [len_ > 0 for len_ in line_len]
+    if len(line_indent) >= 2:
+        if line_len[0] != 0:
+            indents = [x for x, f in zip(line_indent, is_nonzero) if f]
+            if len(indents) >= 2:
+                indent_adjust = min(indents[1:])
+                line_indent[0] += indent_adjust
+                line_len[0] += indent_adjust
+                docstr_lines[0] = (' ' * indent_adjust) + docstr_lines[0]
+                adjusted = True
+    if adjusted:
+        # Redo prepreocessing, but this time on a rectified input
+        docstr = textwrap.dedent('\n'.join(docstr_lines))
+        docstr_lines = docstr.split('\n')
+        line_indent = [get_indentation(line) for line in docstr_lines]
+        line_len = [len(line) for line in docstr_lines]
+
+    indents = [x for x, f in zip(line_indent, is_nonzero) if f]
+    if len(indents) >= 1:
+        if indents[0] != 0:
+            print('ERROR IN PARSING')
+            print('adjusted = %r' % (adjusted,))
+            print(docstr)
+            raise AssertionError('Google Style Docstring Missformat')
+
+    base_indent = 0
+    # We will group lines by their indentation.
+    # Rectify empty lines by giving them their parent's indentation.
+    true_indent = []
+    prev_indent = None
+    for indent_, len_ in zip(line_indent, line_len):
+        if len_ == 0:
+            # Empty lines take on their parents indentation
+            indent_ = prev_indent
+        true_indent.append(indent_)
+        prev_indent = indent_
+
+    # List of google style tags grouped by alias
+    tag_groups = [
+        ['Args', 'Arguments', 'Parameters', 'Other Parameters'],
+        ['Kwargs', 'Keyword Args', 'Keyword Arguments'],
+        ['Warns', 'Warning', 'Warnings'],
+        ['Returns', 'Return'],
+        ['Example', 'Examples'],
+        ['Note', 'Notes'],
+        ['Yields', 'Yield'],
+        ['Attributes'],
+        ['Methods'],
+        ['Raises'],
+        ['References'],
+        ['See Also'],
+        ['Todo'],
+    ]
+    # Map aliased tags to a cannonical name (the first item in the group).
+    tag_aliases = {item: group[0] for group in tag_groups for item in group}
+    tag_pattern = '^' + '(' + '|'.join(tag_aliases.keys()) + '): *$'
+
+    group_id = 0
+    prev_indent = 0
+    group_list = []
+    in_tag = False
+    for line_num, (line, indent_) in enumerate(zip(docstr_lines, true_indent)):
+        if re.match(tag_pattern, line):
+            # Check if we can look ahead
+            if line_num + 1 < len(docstr_lines):
+                # A tag is only valid if its next line is properly indented,
+                # empty, or is a tag itself.
+                indent_increase = true_indent[line_num + 1] > base_indent
+                indent_zero = line_len[line_num + 1] == 0
+                matches_tag = re.match(tag_pattern, docstr_lines[line_num + 1])
+                if (indent_increase or indent_zero or matches_tag):
+                    group_id += 1
+                    in_tag = True
+            else:
+                group_id += 1
+                in_tag = True
+        # If the indentation goes back to the base, then we have left the tag
+        elif in_tag and indent_ != prev_indent and indent_ == base_indent:
+            group_id += 1
+            in_tag = False
+        group_list.append(group_id)
+        prev_indent = indent_
+
+    # Group docstr lines by group list
+    groups_ = collections.defaultdict(list)
+    for groupid, line in zip(group_list, docstr_lines):
+        groups_[groupid].append(line)
+
+    groups = []
+    line_offset = 0
+    for k, lines in groups_.items():
+        if len(lines) == 0 or (len(lines) == 1 and len(lines[0]) == 0):
+            continue
+        elif len(lines) >= 1 and re.match(tag_pattern, lines[0]):
+            # An encoded google sub-block
+            key = lines[0].strip().rstrip(':')
+            val = lines[1:]
+            subblock = textwrap.dedent('\n'.join(val))
+        else:
+            # A top level text documentation block
+            key = '__DOC__'
+            val = lines[:]
+            subblock = '\n'.join(val)
+
+        key = tag_aliases.get(key, key)
+        groups.append((key, subblock))
+        line_offset += len(lines)
+    return groups

--- a/jedi/evaluate/google_docscrape.py
+++ b/jedi/evaluate/google_docscrape.py
@@ -40,7 +40,7 @@ def parse_google_retblock(lines):
 
 
 def parse_google_argblock(lines):
-    """
+    r"""
     Args:
         lines (str): the unindented lines from an Args docstring section
 
@@ -50,26 +50,26 @@ def parse_google_argblock(lines):
         http://www.sphinx-doc.org/en/stable/ext/example_google.html#example-google
 
     Example:
-        >>> from jedi.evaluate.docstrings import parse_google_argblock
+        >>> from jedi.evaluate.google_docscrape import *  # NOQA
         >>> # Test various ways that arglines can be written
         >>> line_list = [
-        >>>     'foo1 (int): a description',
-        >>>     'foo2: a description\n    with a newline',
-        >>>     'foo3 (int or str): a description',
-        >>>     'foo4 (int or threading.Thread): a description',
-        >>>     #
-        >>>     # this is sphynx-like typing style
-        >>>     'param1 (:obj:`str`, optional): ',
-        >>>     'param2 (:obj:`list` of :obj:`str`):',
-        >>>     #
-        >>>     # the Type[type] syntax is defined by the python typeing module
-        >>>     'attr1 (Optional[int]): Description of `attr1`.',
-        >>>     'attr2 (List[str]): Description of `attr2`.',
-        >>>     'attr3 (Dict[str, str]): Description of `attr3`.',
-        >>> ]
+        ...     'foo1 (int): a description',
+        ...     'foo2: a description\n    with a newline',
+        ...     'foo3 (int or str): a description',
+        ...     'foo4 (int or threading.Thread): a description',
+        ...     #
+        ...     # this is sphynx-like typing style
+        ...     'param1 (:obj:`str`, optional): ',
+        ...     'param2 (:obj:`list` of :obj:`str`):',
+        ...     #
+        ...     # the Type[type] syntax is defined by the python typeing module
+        ...     'attr1 (Optional[int]): Description of `attr1`.',
+        ...     'attr2 (List[str]): Description of `attr2`.',
+        ...     'attr3 (Dict[str, str]): Description of `attr3`.',
+        ... ]
         >>> lines = '\n'.join(line_list)
         >>> argdict_list = list(parse_google_argblock(lines))
-        >>> print('argdict_list = %s' % (ut.repr4(argdict_list),))
+        >>> # print('argdict_list = %s' % (argdict_list),)
         >>> assert len(argdict_list) == len(line_list)
     """
     name_pat = r'(?P<name>[A-Za-z_][A-Za-z0-9_]*)'
@@ -89,7 +89,7 @@ def parse_google_argblock(lines):
 
 
 def split_google_docblocks(docstr):
-    """
+    r"""
     Args:
         docstr (str): a docstring
 
@@ -98,12 +98,11 @@ def split_google_docblocks(docstr):
             tag and the second item is the bock corresponding to that tag.
 
     Example:
-        >>> from jedi.evaluate.docstrings import *  # NOQA
-        >>> from jedi.evaluate.docstrings import split_google_docblocks
+        >>> from jedi.evaluate.google_docscrape import *  # NOQA
         >>> docstr = split_google_docblocks.__doc__
         >>> groups = split_google_docblocks(docstr)
-        >>> result = ('groups = %s' % (ut.repr2(groups),))
-        >>> print(result)
+        >>> #print('groups = %s' % (groups,))
+        >>> assert len(groups) == 3
     """
     import re
     import textwrap

--- a/test/test_evaluate/test_docstring.py
+++ b/test/test_evaluate/test_docstring.py
@@ -200,7 +200,7 @@ class TestDocstring(unittest.TestCase):
 
     def test_google_follow_args(self):
         from jedi.evaluate import docstrings
-        from future.types import newint, newstr, newlist
+        from jedi._compatibility import builtins
         google_source = dedent('''
         def foobar(x, y):
             """
@@ -220,13 +220,13 @@ class TestDocstring(unittest.TestCase):
         assert len(y_type_list) == 2
         y_base_objs = set([t.base.obj for t in y_type_list])
         x_base_objs = set([t.base.obj for t in x_type_list])
-        assert x_base_objs == {newint, newstr, newlist}
-        assert y_base_objs == {newint, newstr}
+        assert x_base_objs == {builtins.int, builtins.str, builtins.list}
+        assert y_base_objs == {builtins.int, builtins.str}
 
     @unittest.skipIf(numpydoc_unavailable, 'numpydoc module is unavailable')
     def test_numpy_follow_args(self):
         from jedi.evaluate import docstrings
-        from future.types import newint, newstr, newlist
+        from jedi._compatibility import builtins
         numpy_source = dedent('''
         def foobar(x, y):
             """
@@ -247,5 +247,5 @@ class TestDocstring(unittest.TestCase):
         assert len(y_type_list) == 2
         y_base_objs = set([t.base.obj for t in y_type_list])
         x_base_objs = set([t.base.obj for t in x_type_list])
-        assert x_base_objs == {newint, newstr, newlist}
-        assert y_base_objs == {newint, newstr}
+        assert x_base_objs == {builtins.int, builtins.str, builtins.list}
+        assert y_base_objs == {builtins.int, builtins.str}

--- a/test/test_evaluate/test_docstring.py
+++ b/test/test_evaluate/test_docstring.py
@@ -1,5 +1,12 @@
 """
 Testing of docstring related issues and especially ``jedi.docstrings``.
+
+CommandLine:
+    # Switch to the right directory
+    cd $(python -c "import jedi; from os.path import dirname, abspath; print(dirname(dirname(abspath(jedi.__file__))))")
+    # Run the doctests in this module
+    nosetests test/test_evaluate/test_docstring.py --verbose
+
 """
 
 from textwrap import dedent
@@ -7,7 +14,7 @@ import jedi
 from ..helpers import unittest
 
 try:
-    import numpydoc
+    import numpydoc  # NOQA
 except ImportError:
     numpydoc_unavailable = True
 else:
@@ -105,19 +112,6 @@ class TestDocstring(unittest.TestCase):
         assert '__init__' in names
         assert 'mro' not in names  # Exists only for types.
 
-    def test_googlestyle_docstring(self):
-        s = dedent('''
-        def foobar(x, y):
-            """
-            Args:
-                x (int):
-                y (str):
-            """
-            y.''')
-        names = [c.name for c in jedi.Script(s).completions()]
-        assert 'isupper' in names
-        assert 'capitalize' in names
-
     @unittest.skipIf(numpydoc_unavailable, 'numpydoc module is unavailable')
     def test_numpydoc_docstring(self):
         s = dedent('''
@@ -163,3 +157,95 @@ class TestDocstring(unittest.TestCase):
         assert 'capitalize' in names
         assert 'numerator' in names
         assert 'append' in names
+
+    def test_googlestyle_docstring(self):
+        s = dedent('''
+        def foobar(x, y):
+            """
+            Args:
+                x (int):
+                y (str):
+            """
+            y.''')
+        names = [c.name for c in jedi.Script(s).completions()]
+        assert 'isupper' in names
+        assert 'capitalize' in names
+
+    def test_googledoc_docstring_set_of_values(self):
+        s = dedent('''
+        def foobar(x, y):
+            """
+            Args:
+                x ({'foo', 'bar', 100500}):
+            """
+            x.''')
+        names = [c.name for c in jedi.Script(s).completions()]
+        assert 'isupper' in names
+        assert 'capitalize' in names
+        assert 'numerator' in names
+
+    def test_googledoc_alternative_types(self):
+        s = dedent('''
+        def foobar(x, y):
+            """
+            Args:
+                x (int or str or list):
+            """
+            x.''')
+        names = [c.name for c in jedi.Script(s).completions()]
+        assert 'isupper' in names
+        assert 'capitalize' in names
+        assert 'numerator' in names
+        assert 'append' in names
+
+    def test_google_follow_args(self):
+        from jedi.evaluate import docstrings
+        from future.types import newint, newstr, newlist
+        google_source = dedent('''
+        def foobar(x, y):
+            """
+            Args:
+                x (int or str or list):
+                y ({'foo', 'bar', 100500}):
+            """
+            ''')
+        script = jedi.Script(google_source)
+        func = script._get_module().names_dict['foobar'][0].parent
+        evaluator = script._evaluator
+        x_param = func.names_dict['x'][0].parent
+        y_param = func.names_dict['y'][0].parent
+        x_type_list = docstrings.follow_param(evaluator, x_param)
+        y_type_list = docstrings.follow_param(evaluator, y_param)
+        assert len(x_type_list) == 3
+        assert len(y_type_list) == 2
+        y_base_objs = set([t.base.obj for t in y_type_list])
+        x_base_objs = set([t.base.obj for t in x_type_list])
+        assert x_base_objs == {newint, newstr, newlist}
+        assert y_base_objs == {newint, newstr}
+
+    @unittest.skipIf(numpydoc_unavailable, 'numpydoc module is unavailable')
+    def test_numpy_follow_args(self):
+        from jedi.evaluate import docstrings
+        from future.types import newint, newstr, newlist
+        numpy_source = dedent('''
+        def foobar(x, y):
+            """
+            Parameters
+            ----------
+            x : int or str or list
+            y : {'foo', 'bar', 100500}, optional
+            """
+            ''')
+        script = jedi.Script(numpy_source)
+        func = script._get_module().names_dict['foobar'][0].parent
+        evaluator = script._evaluator
+        x_param = func.names_dict['x'][0].parent
+        y_param = func.names_dict['y'][0].parent
+        x_type_list = docstrings.follow_param(evaluator, x_param)
+        y_type_list = docstrings.follow_param(evaluator, y_param)
+        assert len(x_type_list) == 3
+        assert len(y_type_list) == 2
+        y_base_objs = set([t.base.obj for t in y_type_list])
+        x_base_objs = set([t.base.obj for t in x_type_list])
+        assert x_base_objs == {newint, newstr, newlist}
+        assert y_base_objs == {newint, newstr}

--- a/test/test_evaluate/test_docstring.py
+++ b/test/test_evaluate/test_docstring.py
@@ -112,6 +112,8 @@ class TestDocstring(unittest.TestCase):
         assert '__init__' in names
         assert 'mro' not in names  # Exists only for types.
 
+    # ---- Numpy Style Tests ---
+
     @unittest.skipIf(numpydoc_unavailable, 'numpydoc module is unavailable')
     def test_numpydoc_docstring(self):
         s = dedent('''
@@ -158,6 +160,73 @@ class TestDocstring(unittest.TestCase):
         assert 'numerator' in names
         assert 'append' in names
 
+    @unittest.skipIf(numpydoc_unavailable, 'numpydoc module is unavailable')
+    def test_numpy_returns(self):
+        s = dedent('''
+        def foobar(x, y):
+            """
+            Returns
+            ----------
+            int
+            """
+            return x + y
+
+        def bazbiz():
+            z = foobar(2, 2)
+            z.''')
+        script = jedi.Script(s)
+        names = [c.name for c in script.completions()]
+        assert 'numerator' in names
+
+    @unittest.skipIf(numpydoc_unavailable, 'numpydoc module is unavailable')
+    def test_numpy_follow_args(self):
+        from jedi.evaluate import docstrings
+        from jedi._compatibility import builtins
+        numpy_source = dedent('''
+        def foobar(x, y):
+            """
+            Parameters
+            ----------
+            x : int or str or list
+            y : {'foo', 'bar', 100500}, optional
+            """
+            ''')
+        script = jedi.Script(numpy_source)
+        func = script._get_module().names_dict['foobar'][0].parent
+        evaluator = script._evaluator
+        x_param = func.names_dict['x'][0].parent
+        y_param = func.names_dict['y'][0].parent
+        x_type_list = docstrings.follow_param(evaluator, x_param)
+        y_type_list = docstrings.follow_param(evaluator, y_param)
+        assert len(x_type_list) == 3
+        assert len(y_type_list) == 2
+        y_base_objs = set([t.base.obj for t in y_type_list])
+        x_base_objs = set([t.base.obj for t in x_type_list])
+        assert x_base_objs == {builtins.int, builtins.str, builtins.list}
+        assert y_base_objs == {builtins.int, builtins.str}
+
+    @unittest.skipIf(numpydoc_unavailable, 'numpydoc module is unavailable')
+    def test_numpy_find_return_types(self):
+        from jedi.evaluate import docstrings
+        from jedi._compatibility import builtins
+        s = dedent('''
+        def foobar(x, y):
+            """
+            Returns
+            ----------
+            int
+            """
+            return x + y
+            ''')
+        script = jedi.Script(s)
+        func = script._get_module().names_dict['foobar'][0].parent
+        evaluator = script._evaluator
+        types = docstrings.find_return_types(evaluator, func)
+        assert len(types) == 1
+        assert types[0].base.obj is builtins.int
+
+    # ---- Google Style Tests ---
+
     def test_googlestyle_docstring(self):
         s = dedent('''
         def foobar(x, y):
@@ -198,6 +267,22 @@ class TestDocstring(unittest.TestCase):
         assert 'numerator' in names
         assert 'append' in names
 
+    def test_google_returns(self):
+        s = dedent('''
+        def foobar(x, y):
+            """
+            Returns:
+                int: sum of x and y
+            """
+            return x + y
+
+        def bazbiz():
+            z = foobar(2, 2)
+            z.''')
+        script = jedi.Script(s)
+        names = [c.name for c in script.completions()]
+        assert 'numerator' in names
+
     def test_google_follow_args(self):
         from jedi.evaluate import docstrings
         from jedi._compatibility import builtins
@@ -223,29 +308,20 @@ class TestDocstring(unittest.TestCase):
         assert x_base_objs == {builtins.int, builtins.str, builtins.list}
         assert y_base_objs == {builtins.int, builtins.str}
 
-    @unittest.skipIf(numpydoc_unavailable, 'numpydoc module is unavailable')
-    def test_numpy_follow_args(self):
+    def test_google_find_return_types(self):
         from jedi.evaluate import docstrings
         from jedi._compatibility import builtins
-        numpy_source = dedent('''
+        s = dedent('''
         def foobar(x, y):
             """
-            Parameters
-            ----------
-            x : int or str or list
-            y : {'foo', 'bar', 100500}, optional
+            Returns:
+                int: sum of x and y
             """
+            return x + y
             ''')
-        script = jedi.Script(numpy_source)
+        script = jedi.Script(s)
         func = script._get_module().names_dict['foobar'][0].parent
         evaluator = script._evaluator
-        x_param = func.names_dict['x'][0].parent
-        y_param = func.names_dict['y'][0].parent
-        x_type_list = docstrings.follow_param(evaluator, x_param)
-        y_type_list = docstrings.follow_param(evaluator, y_param)
-        assert len(x_type_list) == 3
-        assert len(y_type_list) == 2
-        y_base_objs = set([t.base.obj for t in y_type_list])
-        x_base_objs = set([t.base.obj for t in x_type_list])
-        assert x_base_objs == {builtins.int, builtins.str, builtins.list}
-        assert y_base_objs == {builtins.int, builtins.str}
+        types = docstrings.find_return_types(evaluator, func)
+        assert len(types) == 1
+        assert types[0].base.obj is builtins.int

--- a/test/test_evaluate/test_docstring.py
+++ b/test/test_evaluate/test_docstring.py
@@ -305,8 +305,8 @@ class TestDocstring(unittest.TestCase):
         assert len(y_type_list) == 2
         y_base_objs = set([t.base.obj for t in y_type_list])
         x_base_objs = set([t.base.obj for t in x_type_list])
-        assert x_base_objs == {builtins.int, builtins.str, builtins.list}
-        assert y_base_objs == {builtins.int, builtins.str}
+        assert x_base_objs == set([builtins.int, builtins.str, builtins.list])
+        assert y_base_objs == set([builtins.int, builtins.str])
 
     def test_google_find_return_types(self):
         from jedi.evaluate import docstrings

--- a/test/test_evaluate/test_docstring.py
+++ b/test/test_evaluate/test_docstring.py
@@ -202,8 +202,8 @@ class TestDocstring(unittest.TestCase):
         assert len(y_type_list) == 2
         y_base_objs = set([t.base.obj for t in y_type_list])
         x_base_objs = set([t.base.obj for t in x_type_list])
-        assert x_base_objs == {builtins.int, builtins.str, builtins.list}
-        assert y_base_objs == {builtins.int, builtins.str}
+        assert x_base_objs == set([builtins.int, builtins.str, builtins.list])
+        assert y_base_objs == set([builtins.int, builtins.str])
 
     @unittest.skipIf(numpydoc_unavailable, 'numpydoc module is unavailable')
     def test_numpy_find_return_types(self):

--- a/test/test_evaluate/test_docstring.py
+++ b/test/test_evaluate/test_docstring.py
@@ -105,6 +105,19 @@ class TestDocstring(unittest.TestCase):
         assert '__init__' in names
         assert 'mro' not in names  # Exists only for types.
 
+    def test_googlestyle_docstring(self):
+        s = dedent('''
+        def foobar(x, y):
+            """
+            Args:
+                x (int):
+                y (str):
+            """
+            y.''')
+        names = [c.name for c in jedi.Script(s).completions()]
+        assert 'isupper' in names
+        assert 'capitalize' in names
+
     @unittest.skipIf(numpydoc_unavailable, 'numpydoc module is unavailable')
     def test_numpydoc_docstring(self):
         s = dedent('''

--- a/test/test_evaluate/test_docstring.py
+++ b/test/test_evaluate/test_docstring.py
@@ -5,7 +5,7 @@ CommandLine:
     # Switch to the right directory
     cd $(python -c "import jedi; from os.path import dirname, abspath; print(dirname(dirname(abspath(jedi.__file__))))")
     # Run the doctests in this module
-    nosetests test/test_evaluate/test_docstring.py --verbose
+    tox -e py test/test_evaluate/test_docstring.py
 
 """
 


### PR DESCRIPTION
The purpose of this PR is to address issue #504 properly and improve upon the original attempt submitted in PR #617. It took a bit more time than expected, but I think I have everything working and tested. 

In addition to enhancing jedi with ability to  and return values from google style docstrings, I also included several fixes for numpy style docstrings. 

A summary of what is changed is as follows:

    * [ENH] jedi can now extract type hints for parameters and return values from google style docstrings
    * [ENH] added tests for new google style parsing
    * [ENH] added doctest examples to several functions in jedi/evaluate/docstrings.py
    * [FIX] numpy return type hints are now correctly parsed and used
    * [FIX] jedi can correctly extracts type hints for alternative-type parameters from numpy docstrings
    * [FIX] fixed an exception in python2.7 for numpy set-of-values parameters. 

----

Here is a breif description of how the new google style parsing was implemented: 

To add support for the google style docstrings I attempted to mirror what was happening for numpy style docstrings. I created a file called `jedi/evaluate/docscrape_google.py` to work in a simlar way to `numpydoc.docscrape`. The main work in this file is done by  `split_google_docblocks` which separates the docstring into a list of sections represented as a list of tuples. Each tuple is a pair of section names and unparsed section lines. This split is made primarily using indentation information and a list of known google-style tags. Header aliases are taken into account so Arguments and Args section headers all resolve back to Args in the returned list. 

The publicly facing functions are `parse_google_args` and `parse_google_returns` which get the appropriate Args / Returns / Yields section and then calls either `parse_google_retblock` or `parse_google_argblock` to grab a list of type hints represented as dictionaries. Back in `jedi/evaluate/docstrings.py` I use this new functionality to augment the behavior or `find_return_types` and  `_search_param_in_docstr`. These functions will now try to use google style docstrings if parsing Epydoc/Sphinx docstrings fails. 

When first looking into `jedi/evaluate/docstrings.py` I was having a hard time getting a feel for the information flow of the module. My style of coding is very integrated with an IPython terminal. I ended up creating several example doctests just as a byproduct of needing to define valid input arguments in IPython. 

----

In regards to the numpy docstring changes: 

When running tests in `test/test_evaluate/test_docstring.py` I noticed that `test_numpydoc_alternative_types` and `test_numpydoc_docstring_set_of_values` were failing. I tracked the issue down to `_search_param_in_numpydocstr`. One test was failing because support for alternative types was just not there, so I added that. The other test was failing because of a python2.7 issue where `ast.literal_eval` raises a `ValueError: malformed string` when trying to parse set literals. This feature is just not supported in python2.7. My fix for this was to replace curly brakets with square brakets in python2. I also ended up separating both of these functionalies into a new function called `_expand_typestr` so I could re-use functionality for the google docstring implementations.

Also, when in this file I also noticed that `find_return_types` was not making any use of numpy docs. I made a function `_search_return_in_numpydocstr` to fix this. 

I added new test to test numpy return type hints in `test_docstrings.py` and ensured that the other numpy tests are no longer failing.

---

Overall I am happy with the current state of the PR and I feel like I'm ready to submit it for review. 
Let me know if there is anything that doesn't make sense or if any changes need to be made. There are a few places that I would like to point out / would like feedback on: 

* In a few places I made modifications that don't actually change the behavior. The reason I did this was mostly due to debugging and needing to inspect how code was working as well as copy lines into IPython. In some of these cases I did not revert the changes. If either I or someone else needs to debug this code again it might be helpful to have those changes. If it would be better to revert back to the original state I can do this. 

* In `parse_google_retblock` there is a corner case that I'm not sure how to handle. Without making a grammar I can't figure out how to differentiate the case where only a type is specified with the case that only a description is specified. For now I'm just assuming that if this occurs the type is specified and if it is not a valid type I'm relying on this value to be thrown out further upstream. If anyone has a better way to do this / suggestions for what the grammar should look like I'm open to hearing it. 

* Should this change be added to the CHANGELOG.rst like I have done or is there a different way to do it?

* I'll make other minor comments in the diff view where necessary
