### PR TITLE
docstrings: fix "Sphinx param with type" pattern

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -42,6 +42,7 @@ Cristi Burcă (@scribu)
 bstaint (@bstaint)
 Mathias Rav (@Mortal) <rav@cs.au.dk>
 Daniel Fiterman (@dfit99) <fitermandaniel2@gmail.com>
+Simon Ruggier (@sruggier)
 
 
 Note: (@user) means a github user name.

--- a/jedi/evaluate/docstrings.py
+++ b/jedi/evaluate/docstrings.py
@@ -31,7 +31,7 @@ from jedi.parser_utils import clean_scope_docstring
 
 DOCSTRING_PARAM_PATTERNS = [
     r'\s*:type\s+%s:\s*([^\n]+)',  # Sphinx
-    r'\s*:param\s+(\w+)\s+%s:[^\n]+',  # Sphinx param with type
+    r'\s*:param\s+(\w+)\s+%s:[^\n]*',  # Sphinx param with type
     r'\s*@type\s+%s:\s*([^\n]+)',  # Epydoc
 ]
 

--- a/test/completion/docstring.py
+++ b/test/completion/docstring.py
@@ -49,6 +49,17 @@ def sphinxy2(a, b, x):
 #? 
 sphinxy2()
 
+
+def sphinxy_param_type_wrapped(a):
+    """
+    :param str a:
+        Some description wrapped onto the next line with no space after the
+        colon.
+    """
+    #? str()
+    a
+
+
 # local classes -> github #370
 class ProgramNode():
     pass


### PR DESCRIPTION
Previously, the pattern only matched if the parameter description
followed on the same line, like so:

    :param type foo: A param named foo.

However, it's also valid for the parameter description to be wrapped
onto the next line, like so:

    :param type foo:
        A param named foo.

This change updates the pattern to match the second example as well.

Fixes #806.