### PR TITLE
Build universal wheels

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal=1


### PR DESCRIPTION
This tells wheel that the packages are compatible with Python 2 and 3.

The wheel currently on PyPI is only tagged 'py2', so installing on Python 3 uses the source tarball (which is why I noticed #846).