### PR TITLE
Complete dotted names properly in decorators

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -40,6 +40,7 @@ Guido van Rossum (@gvanrossum) <guido@python.org>
 Dmytro Sadovnychyi (@sadovnychyi) <jedi@dmit.ro>
 Cristi Burcă (@scribu)
 bstaint (@bstaint)
+Mathias Rav (@Mortal) <rav@cs.au.dk>
 
 
 Note: (@user) means a github user name.

--- a/jedi/api/completion.py
+++ b/jedi/api/completion.py
@@ -164,7 +164,7 @@ class Completion:
                 # No completions for ``with x as foo`` and ``import x as foo``.
                 # Also true for defining names as a class or function.
                 return list(self._get_class_context_completions(is_function=True))
-            elif symbol_names[-1] == 'trailer' and nodes[-1] == '.':
+            elif symbol_names[-1] in ('trailer', 'dotted_name') and nodes[-1] == '.':
                 dot = self._module_node.get_leaf_for_position(self._position)
                 completion_names += self._trailer_completions(dot.get_previous_leaf())
             else:

--- a/test/test_evaluate/test_compiled.py
+++ b/test/test_evaluate/test_compiled.py
@@ -83,3 +83,19 @@ def test_method_completion():
     else:
         result = ['__func__']
     assert [c.name for c in Script(code).completions()] == result
+
+
+def test_decorator_global():
+    code = dedent('''
+    import abc
+    @abc''')
+    result = ['abc']
+    assert [c.name for c in Script(code).completions()] == result
+
+
+def test_decorator_dotted():
+    code = dedent('''
+    import abc
+    @abc.abstractmethod''')
+    result = ['abstractmethod']
+    assert [c.name for c in Script(code).completions()] == result


### PR DESCRIPTION
Outside decorators, a dotted name is parsed by the grammar as
```
stmt -> test -> power -> atom trailer -> (NAME) ('.' NAME)
```
where the first `NAME` is an `atom` and the second `NAME` is a `trailer`.

Thus, testing if the most recent variable is a `trailer` and the most recent node is a `'.'` is almost always enough for Jedi to properly complete dotted names.

However, the grammar for decorators is more restricted and doesn't allow arbitrary atoms and trailers; instead, a dotted name in a decorator is
```
decorator -> '@' dotted_name -> '@' (NAME '.' NAME),
```
meaning the most recent variable will be `dotted_name`, not `trailer`.

Besides in decorators, the `dotted_name` variable is only used in import statements which are handled previously in `_get_context_completions`, so checking for `dotted_name` in this arm of the `if` only covers decorators and not inadvertently anything else.