### PR TITLE
Performance improvement.

### DIFF
--- a/jedi/evaluate/compiled/mixed.py
+++ b/jedi/evaluate/compiled/mixed.py
@@ -3,6 +3,7 @@ Used only for REPL Completion.
 """
 
 import inspect
+import functools
 import os
 
 from jedi import common
@@ -11,6 +12,9 @@ from jedi.evaluate import compiled
 from jedi.cache import underscore_memoization
 from jedi.evaluate import imports
 from jedi.evaluate.context import Context
+
+
+lru_cache = getattr(functools, 'lru_cache', lambda:(lambda x:x))
 
 
 class MixedObject(object):
@@ -115,6 +119,7 @@ class MixedObjectFilter(compiled.CompiledObjectFilter):
         #return MixedName(self._evaluator, self._compiled_object, name)
 
 
+@lru_cache()
 def parse(grammar, path):
     with open(path) as f:
         source = f.read()

--- a/jedi/parser/tokenize.py
+++ b/jedi/parser/tokenize.py
@@ -233,6 +233,8 @@ def generate_tokens(readline, use_exact_op_types=False):
         if not line:
             if contstr:
                 yield TokenInfo(ERRORTOKEN, contstr, contstr_start, prefix)
+                if contstr.endswith('\n'):
+                    new_line = True
             break
 
         lnum += 1


### PR DESCRIPTION
Followup #850. It's late but I push my work to resume it tomorrow and let you know I'm working on it.

```
 ~/dev/ipython master "!!" $ time python jedi_slow.py # with patch
        2.20 real         1.91 user         0.20 sys
 ~/dev/ipython master "!!" $ time python jedi_slow.py # without.
       21.48 real        21.05 user         0.30 sys
 ~/dev/ipython master "!!" $ cat jedi_slow.py
import matplotlib
import jedi
cp = jedi.Interpreter('matplotlib.', [{'matplotlib':matplotlib}], line=1, column=len('matplotlib.')).completions()

for c in cp:
   a = c.type
```

Also [stay away as far as you can from difflib from stdlib if you can](http://carreau.github.io/posts/08-Dear-DiffLib.html). Also because it has some between O(n^2) and O(n^3) behavior in some weird input. I need to finish writing my difflib2 package, and publish the benchmarks. So I'm sure I can write a small standalone differ that would speed the diffparser of Jedi.

(I have to recheck some microbenchmark)