### PR TITLE
Catch FileNotFoundError when opening file cache

### DIFF
--- a/jedi/parser/utils.py
+++ b/jedi/parser/utils.py
@@ -10,6 +10,7 @@ import pickle
 
 from jedi import settings
 from jedi import debug
+from jedi._compatibility import FileNotFoundError
 
 
 def underscore_memoization(func):
@@ -127,12 +128,15 @@ class ParserPickling(object):
             # the pickle file is outdated
             return None
 
-        with open(self._get_hashed_path(path), 'rb') as f:
-            try:
-                gc.disable()
-                parser_cache_item = pickle.load(f)
-            finally:
-                gc.enable()
+        try:
+            with open(self._get_hashed_path(path), 'rb') as f:
+                try:
+                    gc.disable()
+                    parser_cache_item = pickle.load(f)
+                finally:
+                    gc.enable()
+        except FileNotFoundError:
+            return None
 
         debug.dbg('pickle loaded: %s', path)
         parser_cache[path] = parser_cache_item


### PR DESCRIPTION
After running jedi a long time, a cache file might get deleted, causing a crash when it is opened. This commit handles the FileNotFoundError gracefully.