### PR TITLE
Return types from numpydocs and compiled objects return types from docstrings

### DIFF
--- a/jedi/evaluate/compiled/__init__.py
+++ b/jedi/evaluate/compiled/__init__.py
@@ -205,9 +205,9 @@ class CompiledObject(Context):
         return CompiledContextName(self, name)
 
     def _execute_function(self, params):
+        from jedi.evaluate import docstrings
         if self.type != 'funcdef':
             return
-
         for name in self._parse_function_doc()[1].split():
             try:
                 bltn_obj = getattr(_builtins, name)
@@ -221,6 +221,8 @@ class CompiledObject(Context):
                 bltn_obj = create(self.evaluator, bltn_obj)
                 for result in self.evaluator.execute(bltn_obj, params):
                     yield result
+        for type_ in docstrings.infer_return_types(self):
+            yield type_
 
     def get_self_attributes(self):
         return []  # Instance compatibility

--- a/test/test_evaluate/test_docstring.py
+++ b/test/test_evaluate/test_docstring.py
@@ -285,6 +285,28 @@ def test_numpydoc_returns_obj():
     assert 'numerator' in names
     assert 'seed' in names
 
+@pytest.mark.skipif(numpydoc_unavailable, 
+                    reason='numpydoc module is unavailable')
+def test_numpydoc_yields():
+    s = dedent('''
+    def foobar():
+        """
+        Yields
+        ----------
+        x : int
+        y : str
+        """
+        return x
+
+    def bazbiz():
+        z = foobar():
+        z.''')
+    names = [c.name for c in jedi.Script(s).completions()]
+    print('names',names)
+    assert 'isupper' in names
+    assert 'capitalize' in names
+    assert 'numerator' in names
+
 @pytest.mark.skipif(numpydoc_unavailable or numpy_unavailable, 
                     reason='numpydoc or numpy module is unavailable')
 def test_numpy_returns():

--- a/test/test_evaluate/test_docstring.py
+++ b/test/test_evaluate/test_docstring.py
@@ -4,14 +4,22 @@ Testing of docstring related issues and especially ``jedi.docstrings``.
 
 from textwrap import dedent
 import jedi
+import pytest
 from ..helpers import unittest
 
 try:
-    import numpydoc
+    import numpydoc  # NOQA
 except ImportError:
     numpydoc_unavailable = True
 else:
     numpydoc_unavailable = False
+    
+try:
+    import numpy
+except ImportError:
+    numpy_unavailable = True
+else:
+    numpy_unavailable = False
 
 
 class TestDocstring(unittest.TestCase):
@@ -124,48 +132,174 @@ class TestDocstring(unittest.TestCase):
         completions = jedi.Script('assert').completions()
         self.assertIn('assert', completions[0].docstring())
 
-    @unittest.skipIf(numpydoc_unavailable, 'numpydoc module is unavailable')
-    def test_numpydoc_docstring(self):
-        s = dedent('''
-        def foobar(x, y):
-            """
-            Parameters
-            ----------
-            x : int
-            y : str
-            """
-            y.''')
-        names = [c.name for c in jedi.Script(s).completions()]
-        assert 'isupper' in names
-        assert 'capitalize' in names
+# ---- Numpy Style Tests ---
 
-    @unittest.skipIf(numpydoc_unavailable, 'numpydoc module is unavailable')
-    def test_numpydoc_docstring_set_of_values(self):
-        s = dedent('''
-        def foobar(x, y):
-            """
-            Parameters
-            ----------
-            x : {'foo', 'bar', 100500}, optional
-            """
-            x.''')
-        names = [c.name for c in jedi.Script(s).completions()]
-        assert 'isupper' in names
-        assert 'capitalize' in names
-        assert 'numerator' in names
+@pytest.mark.skipif(numpydoc_unavailable, 
+                    reason='numpydoc module is unavailable')
+def test_numpydoc_parameters():
+    s = dedent('''
+    def foobar(x, y):
+        """
+        Parameters
+        ----------
+        x : int
+        y : str
+        """
+        y.''')
+    names = [c.name for c in jedi.Script(s).completions()]
+    assert 'isupper' in names
+    assert 'capitalize' in names
 
-    @unittest.skipIf(numpydoc_unavailable, 'numpydoc module is unavailable')
-    def test_numpydoc_alternative_types(self):
-        s = dedent('''
-        def foobar(x, y):
-            """
-            Parameters
-            ----------
-            x : int or str or list
-            """
-            x.''')
-        names = [c.name for c in jedi.Script(s).completions()]
-        assert 'isupper' in names
-        assert 'capitalize' in names
-        assert 'numerator' in names
-        assert 'append' in names
+@pytest.mark.skipif(numpydoc_unavailable, 
+                    reason='numpydoc module is unavailable')
+def test_numpydoc_parameters_set_of_values():
+    s = dedent('''
+    def foobar(x, y):
+        """
+        Parameters
+        ----------
+        x : {'foo', 'bar', 100500}, optional
+        """
+        x.''')
+    names = [c.name for c in jedi.Script(s).completions()]
+    assert 'isupper' in names
+    assert 'capitalize' in names
+    assert 'numerator' in names
+
+@pytest.mark.skipif(numpydoc_unavailable, 
+                    reason='numpydoc module is unavailable')
+def test_numpydoc_parameters_alternative_types():
+    s = dedent('''
+    def foobar(x, y):
+        """
+        Parameters
+        ----------
+        x : int or str or list
+        """
+        x.''')
+    names = [c.name for c in jedi.Script(s).completions()]
+    assert 'isupper' in names
+    assert 'capitalize' in names
+    assert 'numerator' in names
+    assert 'append' in names
+
+def test_numpydoc_returns():
+    s = dedent('''
+    def foobar():
+        """
+        Returns
+        ----------
+        x : int
+        y : str
+        """
+        return x
+
+    def bazbiz():
+        z = foobar()
+        z.''')
+    names = [c.name for c in jedi.Script(s).completions()]
+    assert 'isupper' in names
+    assert 'capitalize' in names
+    assert 'numerator' in names
+
+@pytest.mark.skipif(numpydoc_unavailable, 
+                    reason='numpydoc module is unavailable')
+def test_numpydoc_returns_set_of_values():
+    s = dedent('''
+    def foobar():
+        """
+        Returns
+        ----------
+        x : {'foo', 'bar', 100500}
+        """
+        return x
+
+    def bazbiz():
+        z = foobar()
+        z.''')
+    names = [c.name for c in jedi.Script(s).completions()]
+    assert 'isupper' in names
+    assert 'capitalize' in names
+    assert 'numerator' in names
+
+@pytest.mark.skipif(numpydoc_unavailable, 
+                    reason='numpydoc module is unavailable')
+def test_numpydoc_returns_alternative_types():
+    s = dedent('''
+    def foobar():
+        """
+        Returns
+        ----------
+        int or list of str
+        """
+        return x
+
+    def bazbiz():
+        z = foobar()
+        z.''')
+    names = [c.name for c in jedi.Script(s).completions()]
+    assert 'isupper' not in names
+    assert 'capitalize' not in names
+    assert 'numerator' in names
+    assert 'append' in names
+
+def test_numpydoc_returns_list_of():
+    s = dedent('''
+    def foobar():
+        """
+        Returns
+        ----------
+        list of str
+        """
+        return x
+
+    def bazbiz():
+        z = foobar()
+        z.''')
+    names = [c.name for c in jedi.Script(s).completions()]
+    assert 'append' in names
+    assert 'isupper' not in names
+    assert 'capitalize' not in names
+
+@pytest.mark.skipif(numpydoc_unavailable, 
+                    reason='numpydoc module is unavailable')
+def test_numpydoc_returns_obj():
+    s = dedent('''
+    def foobar(x, y):
+        """
+        Returns
+        ----------
+        int or random.Random
+        """
+        return x + y
+
+    def bazbiz():
+        z = foobar(x, y)
+        z.''')
+    script = jedi.Script(s)
+    names = [c.name for c in script.completions()]
+    assert 'numerator' in names
+    assert 'seed' in names
+
+@pytest.mark.skipif(numpydoc_unavailable or numpy_unavailable, 
+                    reason='numpydoc or numpy module is unavailable')
+def test_numpy_returns():
+    s = dedent('''
+    import numpy
+    x = numpy.asarray([])
+    x.d''')
+    names = [c.name for c in jedi.Script(s).completions()]
+    print(names)
+    assert 'diagonal' in names
+
+@pytest.mark.skipif(numpydoc_unavailable or numpy_unavailable, 
+                    reason='numpydoc or numpy module is unavailable')
+def test_numpy_comp_returns():
+    s = dedent('''
+    import numpy
+    x = numpy.array([])
+    x.d''')
+    names = [c.name for c in jedi.Script(s).completions()]
+    print(names)
+    assert 'diagonal' in names
+    

--- a/test/test_evaluate/test_docstring.py
+++ b/test/test_evaluate/test_docstring.py
@@ -183,6 +183,8 @@ def test_numpydoc_parameters_alternative_types():
     assert 'numerator' in names
     assert 'append' in names
 
+@pytest.mark.skipif(numpydoc_unavailable, 
+                    reason='numpydoc module is unavailable')
 def test_numpydoc_returns():
     s = dedent('''
     def foobar():
@@ -242,7 +244,9 @@ def test_numpydoc_returns_alternative_types():
     assert 'capitalize' not in names
     assert 'numerator' in names
     assert 'append' in names
-
+    
+@pytest.mark.skipif(numpydoc_unavailable, 
+                    reason='numpydoc module is unavailable')
 def test_numpydoc_returns_list_of():
     s = dedent('''
     def foobar():

--- a/tox.ini
+++ b/tox.ini
@@ -8,8 +8,6 @@ deps =
     docopt
 # coloroma for colored debug output
     colorama
-# numpydoc for typing scipy stack
-    numpydoc
 setenv =
 # https://github.com/tomchristie/django-rest-framework/issues/1957
 # tox corrupts __pycache__, solution from here:
@@ -24,6 +22,8 @@ deps =
 deps =
 # for testing the typing module
     typing
+# numpydoc for typing scipy stack
+    numpydoc
     {[testenv]deps}
 [testenv:py33]
 deps =
@@ -32,9 +32,11 @@ deps =
 [testenv:py34]
 deps =
     typing
+    numpydoc
     {[testenv]deps}
 [testenv:py35]
 deps =
+    numpydoc
     {[testenv]deps}
 [testenv:cov]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,8 @@ deps =
     docopt
 # coloroma for colored debug output
     colorama
+# numpydoc for typing scipy stack
+    numpydoc
 setenv =
 # https://github.com/tomchristie/django-rest-framework/issues/1957
 # tox corrupts __pycache__, solution from here:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py33, py34, py35
+envlist = py26, py27, py33, py34, py35, py36
 [testenv]
 deps =
     pytest>=2.3.5
@@ -35,6 +35,10 @@ deps =
     numpydoc
     {[testenv]deps}
 [testenv:py35]
+deps =
+    numpydoc
+    {[testenv]deps}
+[testenv:py36]
 deps =
     numpydoc
     {[testenv]deps}

--- a/tox.ini
+++ b/tox.ini
@@ -45,6 +45,7 @@ deps =
 [testenv:cov]
 deps =
     coverage
+    numpydoc
     {[testenv]deps}
 commands =
     coverage run --source jedi -m py.test


### PR DESCRIPTION
In this PR I have updated the docstrings.py from @erotemic in PR: #796 so that it merges against the changes that have been made to the current dev branch since the original commits. I have also removed the google docstrings from this PR as I don't have the experience necessary to test these docstrings. However, It should be quite simple for @erotemic to add this functionality as an addition PR. With this split there are less code changes, hopefully making this PR easier to merge.

This pull request solves issue #372 for numpy complied objects. 

Numpy functions such as numpy.array return an numpy.ndarray object resulting in completions like this:

> import jedi; jedi.Script('import numpy as np; np.array([1,2,3]).a').completions()
[<Completion: all>,
 <Completion: any>,
 <Completion: argmax>,
 <Completion: argmin>,
 <Completion: argpartition>,
 <Completion: argsort>,
 <Completion: astype>]

I have not yet written a test since I need to import numpydocs and numpy to do such. 
A standard python library with complied objects and sphinx documentation would be a better test.