### PR TITLE
Only resolve names for actual modules in usages

### DIFF
--- a/jedi/api/usages.py
+++ b/jedi/api/usages.py
@@ -14,8 +14,9 @@ def usages(evaluator, definition_names, mods):
             if name.api_type == 'module':
                 found = False
                 for context in name.infer():
-                    found = True
-                    yield context.name
+                    if isinstance(context, ModuleContext):
+                        found = True
+                        yield context.name
                 if not found:
                     yield name
             else:

--- a/test/completion/usages.py
+++ b/test/completion/usages.py
@@ -83,17 +83,18 @@ import module_not_exists
 module_not_exists
 
 
-#< ('rename1', 1,0), (0,24), (3,0), (6,17), ('rename2', 4,5), (10,17), (13,17), ('imports', 72, 16)
+#< ('rename1', 1,0), (0,24), (3,0), (6,17), ('rename2', 4,5), (11,17), (14,17), ('imports', 72, 16)
 from import_tree import rename1
 
-#< (0,8), ('rename1',3,0), ('rename2',4,20), ('rename2',6,0), (3,32), (7,32), (4,0)
+#< (0,8), ('rename1',3,0), ('rename2',4,20), ('rename2',6,0), (3,32), (8,32), (5,0)
 rename1.abc
 
-#< (-3,8), ('rename1', 3,0), ('rename2', 4,20), ('rename2', 6,0), (0,32), (4,32), (1,0)
+#< (-3,8), ('rename1', 3,0), ('rename2', 4,20), ('rename2', 6,0), (0,32), (5,32), (2,0)
 from import_tree.rename1 import abc
+#< (-5,8), (-2,32), ('rename1', 3,0), ('rename2', 4,20), ('rename2', 6,0), (0,0), (3,32)
 abc
 
-#< 20 ('rename1', 1,0), ('rename2', 4,5), (-10,24), (-7,0), (-4,17), (0,17), (3,17), ('imports', 72, 16)
+#< 20 ('rename1', 1,0), ('rename2', 4,5), (-11,24), (-8,0), (-5,17), (0,17), (3,17), ('imports', 72, 16)
 from import_tree.rename1 import abc
 
 #< (0, 32),


### PR DESCRIPTION
Consider the following files:
```python
# file1.py
abc = 3
```
```python
# file2.py
from file1 import abc
abc
```
When calling `usages` on the second `abc` in file2.py, Jedi will return these definitions :

Definition | File | Cursor position
--- | --- | ---
\<Definition instance int> | None | (None, None)
\<Definition abc = 3> | file1.py | (2, 0)
\<Definition instance abc>| file2.py | (2, 10)
\<Definition abc> | file2.py | (3, 0)

Obviously, the first definition shouldn't be returned. AFAIK, this happens because Jedi assumes that `abc` on the import line is of type `module` in [the `resolve_names` function](https://github.com/davidhalter/jedi/blob/master/jedi/api/usages.py#L12-L22) which is not the case. This is fixed by checking that the underlying types (contexts) are actual modules.

Added a test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/davidhalter/jedi/881)
<!-- Reviewable:end -->
