### PR TITLE
Don't run SequenceMatcher on identical  input.

### DIFF
--- a/jedi/parser/diff.py
+++ b/jedi/parser/diff.py
@@ -154,6 +154,9 @@ class DiffParser(object):
 
         line_length = len(lines_new)
         lines_old = splitlines(self._parser.source, keepends=True)
+        if lines_old == self._parser_lines_new:
+            self._copy_count = 1
+            return self._module
         sm = difflib.SequenceMatcher(None, lines_old, self._parser_lines_new)
         opcodes = sm.get_opcodes()
         debug.speed('diff parser calculated')


### PR DESCRIPTION
Seem like obvious optimisation but SequenceMatcher does not do it.