### PR TITLE
Implement signal for stopping Jedi execution

### DIFF
--- a/jedi/evaluate/recursion.py
+++ b/jedi/evaluate/recursion.py
@@ -11,7 +11,7 @@ from contextlib import contextmanager
 
 from jedi import debug
 from jedi import settings
-
+from jedi.stop_signal import poll_and_handle_stop_execution_signal_at_start
 
 class RecursionDetector(object):
     def __init__(self):
@@ -78,6 +78,7 @@ class ExecutionRecursionDetector(object):
         self.parent_execution_funcs.pop()
         self.recursion_level -= 1
 
+    @poll_and_handle_stop_execution_signal_at_start
     def push_execution(self, execution):
         in_par_execution_funcs = execution.tree_node in self.parent_execution_funcs
         in_execution_funcs = execution.tree_node in self.execution_funcs

--- a/jedi/stop_signal.py
+++ b/jedi/stop_signal.py
@@ -1,0 +1,28 @@
+try:
+    from queue import Queue
+except ImportError:
+    # Python 2 shim
+    from Queue import Queue
+
+stop_execution_signal_queue = Queue(maxsize=1)
+"""
+Allows a controller thread to cause Jedi to abort execution.
+`ExecutionRecursionDetector.push_execution` will raise `StopExecutionException`
+if the `stop_execution_signal_queue` is not empty.
+"""
+
+class StopExecutionException(Exception):
+    """Raised when Jedi aborts execution"""
+    pass
+
+
+def poll_and_handle_stop_execution_signal():
+    if not stop_execution_signal_queue.empty():
+        stop_execution_signal_queue.get()
+        raise StopExecutionException('Received signal to stop execution.')
+
+def poll_and_handle_stop_execution_signal_at_start(function):
+    def wrapper(obj, *args, **kwargs):
+        poll_and_handle_stop_execution_signal()
+        return function(obj, *args, **kwargs)
+    return wrapper


### PR DESCRIPTION
I am implementing a code analysis tool that uses Jedi. I was having trouble with runaway Jedi execution, and also general responsiveness. This PR solves these problems.

# Commit message:
Implement `jedi.evaluate.recursion.stop_execution_signal_queue`. This
allows a controller thread to stop Jedi execution, for improved
responsiveness.

