### PR TITLE
Fix : Jedi do not complete numpy arrays in dictionary

### DIFF
--- a/jedi/evaluate/compiled/__init__.py
+++ b/jedi/evaluate/compiled/__init__.py
@@ -556,7 +556,7 @@ def create(evaluator, obj, parent_context=None, module=None, faked=None):
             # Modules don't have parents, be careful with caching: recurse.
             return create(evaluator, obj)
     else:
-        if parent_context is None and obj != _builtins:
+        if parent_context is None and obj is not _builtins:
             return create(evaluator, obj, create(evaluator, _builtins))
 
         try:

--- a/test/test_api/test_interpreter.py
+++ b/test/test_api/test_interpreter.py
@@ -41,6 +41,36 @@ def test_builtin_details():
     assert m.type == 'module'
 
 
+def test_numpy_like_non_zero():
+    """
+    Numpy-like array can't be caster to bool and need to be compacre with
+    `is`/`is not` and not `==`/`!=`
+    """
+
+    class NumpyNonZero:
+
+        def __zero__(self):
+            raise ValueError('Numpy arrays would raise and tell you to use .any() or all()')
+        def __bool__(self):
+            raise ValueError('Numpy arrays would raise and tell you to use .any() or all()')
+
+    class NumpyLike:
+
+        def __eq__(self, other):
+            return NumpyNonZero()
+
+        def something(self):
+            pass
+
+    x = NumpyLike()
+    d = {'a': x}
+
+    # just assert these do not raise. They (strangely) trigger different
+    # codepath
+    get_completion('d["a"].some', {'d':d})
+    get_completion('x.some', {'x':x})
+
+
 def test_nested_resolve():
     class XX():
         def x():


### PR DESCRIPTION
Fix ipython/ipython#10468

@stefanv does that fix your issue ? You should "just" have to install Jedi from the `dev` branch. 