### PR TITLE
Use stacklevel in warnings or filters don't work.

### DIFF
--- a/jedi/api/__init__.py
+++ b/jedi/api/__init__.py
@@ -93,10 +93,10 @@ class Script(object):
                  encoding='utf-8', source_path=None, source_encoding=None,
                  sys_path=None):
         if source_path is not None:
-            warnings.warn("Use path instead of source_path.", DeprecationWarning)
+            warnings.warn("Deprecated since version 0.7. Use path instead of source_path.", DeprecationWarning, stacklevel=2)
             path = source_path
         if source_encoding is not None:
-            warnings.warn("Use encoding instead of source_encoding.", DeprecationWarning)
+            warnings.warn("Deprecated since version 0.8. Use encoding instead of source_encoding.", DeprecationWarning, stacklevel=2)
             encoding = source_encoding
 
         self._orig_path = path
@@ -158,7 +158,7 @@ class Script(object):
            Use :attr:`.path` instead.
         .. todo:: Remove!
         """
-        warnings.warn("Use path instead of source_path.", DeprecationWarning)
+        warnings.warn("Deprecated since version 0.7. Use path instead of source_path.", DeprecationWarning, stacklevel=2)
         return self.path
 
     def __repr__(self):

--- a/jedi/api/classes.py
+++ b/jedi/api/classes.py
@@ -254,7 +254,7 @@ class BaseDefinition(object):
            Use :meth:`.docstring` instead.
         .. todo:: Remove!
         """
-        warnings.warn("Use docstring() instead.", DeprecationWarning)
+        warnings.warn("Deprecated since Jedi 0.8. Use docstring() instead.", DeprecationWarning, stacklevel=2)
         return self.docstring(raw=False)
 
     @property
@@ -264,7 +264,7 @@ class BaseDefinition(object):
            Use :meth:`.docstring` instead.
         .. todo:: Remove!
         """
-        warnings.warn("Use docstring() instead.", DeprecationWarning)
+        warnings.warn("Deprecated since Jedi 0.8. Use docstring() instead.", DeprecationWarning, stacklevel=2)
         return self.docstring(raw=True)
 
     @property
@@ -656,7 +656,7 @@ class CallSignature(Definition):
 
         The name (e.g. 'isinstance') as a string.
         """
-        warnings.warn("Use name instead.", DeprecationWarning)
+        warnings.warn("Deprecated since Jedi 0.8. Use name instead.", DeprecationWarning, stacklevel=2)
         return self.name
 
     @property
@@ -685,7 +685,7 @@ class _Param(Definition):
 
         A function to get the whole code of the param.
         """
-        warnings.warn("Use description instead.", DeprecationWarning)
+        warnings.warn("Deprecated since version 0.8. Use description instead.", DeprecationWarning, stacklevel=2)
         return self.description
 
 


### PR DESCRIPTION
In particular with the right stacklevel IPython will display the warning
if code is directly entered by the user. Without this info it does not.

Use the opportunity to add in the warning since when things are
deprecated. This leads to one less lookup of information for the user.