### PR TITLE
Speed up cached completions

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -44,6 +44,7 @@ Mathias Rav (@Mortal) <rav@cs.au.dk>
 Daniel Fiterman (@dfit99) <fitermandaniel2@gmail.com>
 Simon Ruggier (@sruggier)
 Élie Gouzien (@ElieGouzien)
+Joe Gordon (@jogo)
 
 
 Note: (@user) means a github user name.

--- a/jedi/cache.py
+++ b/jedi/cache.py
@@ -11,6 +11,7 @@ This module is one of the reasons why |jedi| is not thread-safe. As you can see
 there are global variables, which are holding the cache information. Some of
 these variables are being cleaned after every API usage.
 """
+from functools import wraps
 import time
 import inspect
 
@@ -111,14 +112,15 @@ def time_cache(time_add_setting):
 
 def memoize_method(method):
     """A normal memoize function."""
-    def wrapper(self, *args, **kwargs):
-        cache_dict = self.__dict__.setdefault('_memoize_method_dct', {})
-        dct = cache_dict.setdefault(method, {})
+    cache = {}
+
+    @wraps(method)
+    def wrapper(*args, **kwargs):
         key = (args, frozenset(kwargs.items()))
         try:
-            return dct[key]
+            return cache[key]
         except KeyError:
-            result = method(self, *args, **kwargs)
-            dct[key] = result
+            result = method(*args, **kwargs)
+            cache[key] = result
             return result
     return wrapper

--- a/jedi/parser/python/tree.py
+++ b/jedi/parser/python/tree.py
@@ -25,6 +25,7 @@ Any subclasses of :class:`Scope`, including :class:`Module` has an attribute
 [<ImportName: import os@1,0>]
 """
 
+from jedi import cache
 from jedi._compatibility import utf8_repr, unicode
 from jedi.parser.tree import Node, BaseNode, Leaf, ErrorNode, ErrorLeaf, \
     search_ancestor
@@ -153,6 +154,7 @@ class Name(_LeafWithoutNewlines):
         return "<%s: %s@%s,%s>" % (type(self).__name__, self.value,
                                    self.line, self.indent)
 
+    @cache.memoize_method
     def is_definition(self):
         if self.parent.type in ('power', 'atom_expr'):
             # In `self.x = 3` self is not a definition, but x is.


### PR DESCRIPTION
Based on cProfile `is_definition` is expensive when
looking up completions with a warm cache. memoize this
function to speed it up.
    
Adjust memoize_method to work with slots, so this works with `is_definition`
    
`jedi.Script('from numpy import ').completions()`
Goes from 0.170 seconds to 0.100 seconds.