### PR TITLE
Fix keyword docstring

### DIFF
--- a/jedi/api/keywords.py
+++ b/jedi/api/keywords.py
@@ -76,11 +76,15 @@ class KeywordName(AbstractNameDefinition):
     api_type = 'keyword'
 
     def __init__(self, evaluator, name):
+        self.evaluator = evaluator
         self.string_name = name
         self.parent_context = evaluator.BUILTINS
 
     def eval(self):
         return set()
+
+    def infer(self):
+        return [Keyword(self.evaluator, self.string_name, (0, 0))]
 
 
 class Keyword(object):
@@ -100,9 +104,8 @@ class Keyword(object):
         """ For a `parsing.Name` like comparision """
         return [self.name]
 
-    @property
-    def docstr(self):
-        return imitate_pydoc(self.name)
+    def py__doc__(self, include_call_signature=False):
+        return imitate_pydoc(self.name.string_name)
 
     def __repr__(self):
         return '<%s: %s>' % (type(self).__name__, self.name)
@@ -136,6 +139,6 @@ def imitate_pydoc(string):
         return ''
 
     try:
-        return pydoc_topics.topics[label] if pydoc_topics else ''
+        return pydoc_topics.topics[label].strip() if pydoc_topics else ''
     except KeyError:
         return ''

--- a/test/test_evaluate/test_docstring.py
+++ b/test/test_evaluate/test_docstring.py
@@ -20,7 +20,7 @@ class TestDocstring(unittest.TestCase):
         def func():
             '''Docstring of `func`.'''
         func""").goto_definitions()
-        self.assertEqual(defs[0].raw_doc, 'Docstring of `func`.')
+        self.assertEqual(defs[0].docstring(), 'func()\n\nDocstring of `func`.')
 
     @unittest.skip('need evaluator class for that')
     def test_attribute_docstring(self):
@@ -28,7 +28,7 @@ class TestDocstring(unittest.TestCase):
         x = None
         '''Docstring of `x`.'''
         x""").goto_definitions()
-        self.assertEqual(defs[0].raw_doc, 'Docstring of `x`.')
+        self.assertEqual(defs[0].docstring(), 'Docstring of `x`.')
 
     @unittest.skip('need evaluator class for that')
     def test_multiple_docstrings(self):
@@ -38,7 +38,7 @@ class TestDocstring(unittest.TestCase):
         x = func
         '''Docstring of `x`.'''
         x""").goto_definitions()
-        docs = [d.raw_doc for d in defs]
+        docs = [d.docstring() for d in defs]
         self.assertEqual(docs, ['Original docstring.', 'Docstring of `x`.'])
 
     def test_completion(self):
@@ -104,6 +104,10 @@ class TestDocstring(unittest.TestCase):
         assert 'a' in names
         assert '__init__' in names
         assert 'mro' not in names  # Exists only for types.
+
+    def test_docstring_keyword(self):
+        completions = jedi.Script('assert').completions()
+        self.assertIn('assert', completions[0].docstring())
 
     @unittest.skipIf(numpydoc_unavailable, 'numpydoc module is unavailable')
     def test_numpydoc_docstring(self):


### PR DESCRIPTION
Jedi raises a `NotImplementedError` exception when asking for the docstring of any Python keyword. For instance, running this code with latest dev branch
```python
import jedi

jedi.Script('assert').completions()[0].docstring()
```
outputs
```python
Traceback (most recent call last):
  File "jedi\jedi\cache.py", line 119, in wrapper
    return dct[key]
KeyError: ((), frozenset({('fast', False)}))

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "test.py", line 10, in <module>
    jedi.Script('assert').completions()[ 0 ].docstring()
  File "jedi\jedi\api\classes.py", line 472, in docstring
    return super(Completion, self).docstring(raw=raw, fast=fast)
  File "jedi\jedi\api\classes.py", line 248, in docstring
    return _Help(self._name).docstring(fast=fast, raw=raw)
  File "jedi\jedi\api\classes.py", line 723, in docstring
    for context in self._get_contexts(fast=fast):
  File "jedi\jedi\cache.py", line 121, in wrapper
    result = method(self, *args, **kwargs)
  File "jedi\jedi\api\classes.py", line 713, in _get_contexts
    return self._name.infer()
  File "jedi\jedi\evaluate\filters.py", line 21, in infer
    raise NotImplementedError
NotImplementedError
```

This is fixed by implementing the `infer` method in `KeywordName` and by replacing the `docstr` property (which is used nowhere) with the `py__doc__` method in `Keyword`. `imitate_pydoc` only accepts a string so we make sure that we pass one and not a `KeywordName` object. Also, we strip the trailing `\n` characters from the docs.

I am not completely sure about the implementation so tell me if things should be done differently and I'll update the PR. In particular, I am wondering if `Keyword` should be a subclass of `Context` since they have `api_type` and `py__doc__` in common.

Added a test and replaced `raw_doc` by `docstring()` in the docstring tests as the former is deprecated in favor of the latter according to the docs.