### PR TITLE
Fix instance docstring

### DIFF
--- a/jedi/evaluate/instance.py
+++ b/jedi/evaluate/instance.py
@@ -197,6 +197,11 @@ class CompiledInstance(AbstractInstanceContext):
 
 
 class TreeInstance(AbstractInstanceContext):
+    def __init__(self, evaluator, parent_context, class_context, var_args):
+        super(TreeInstance, self).__init__(evaluator, parent_context,
+                                           class_context, var_args)
+        self.tree_node = class_context.tree_node
+
     @property
     def name(self):
         return filters.ContextName(self, self.class_context.name.tree_name)

--- a/test/test_evaluate/test_docstring.py
+++ b/test/test_evaluate/test_docstring.py
@@ -22,6 +22,21 @@ class TestDocstring(unittest.TestCase):
         func""").goto_definitions()
         self.assertEqual(defs[0].raw_doc, 'Docstring of `func`.')
 
+    def test_class_doc(self):
+        defs = jedi.Script("""
+        class TestClass():
+            '''Docstring of `TestClass`.'''
+        TestClass""").goto_definitions()
+        self.assertEqual(defs[0].docstring(), 'Docstring of `TestClass`.')
+
+    def test_instance_doc(self):
+        defs = jedi.Script("""
+        class TestClass():
+            '''Docstring of `TestClass`.'''
+        tc = TestClass()
+        tc""").goto_definitions()
+        self.assertEqual(defs[0].docstring(), 'Docstring of `TestClass`.')
+
     @unittest.skip('need evaluator class for that')
     def test_attribute_docstring(self):
         defs = jedi.Script("""


### PR DESCRIPTION
Jedi always returns an empty docstring for an instance. For example, the following code:
```python
import jedi

source = """
class TestClass():
    '''Docstring of `TestClass`.'''
tc = TestClass()
tc"""

definitions = jedi.Script(source).goto_definitions()
print(definitions[0].docstring())
```
returns nothing while it should output ``Docstring of `TestClass`.``. It's a regression introduced by commit 7ca62578e11031ae09a6ad79fd74089de25ed46d. 

This PR fixes the regression and add two docstring tests: one with a class and another with an instance.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/davidhalter/jedi/942)
<!-- Reviewable:end -->
