### PR TITLE
Function annotations as comments, for type support in Python 2.

### DIFF
--- a/jedi/evaluate/pep0484.py
+++ b/jedi/evaluate/pep0484.py
@@ -83,6 +83,50 @@ def _fix_forward_reference(context, node):
 @memoize_default()
 def infer_param(execution_context, param):
     annotation = param.annotation
+    if annotation is None:
+        # If no Python 3-style annotation, look for a Python 2-style comment
+        # annotation.
+        # Identify parameters to function in the same sequence as they would
+        # appear in a type comment.
+        all_params = [child for child in param.parent.children
+            if child.type == 'param']
+
+        node = param.parent.parent
+        comment = parser_utils.get_following_comment_same_line(node)
+        if comment is None:
+            return []
+        match = re.match(r"^#\s*type:\s*\(([^#]*)\)\s*->", comment)
+        if not match:
+            return []
+        param_type_comment = match.group(1)
+        # parse the list of types, watching out for commas inside generics.
+        params_comments = []
+        current_param = ''
+        generic_nesting = 0
+        for param_char in param_type_comment:
+            if param_char == ',' and generic_nesting == 0:
+                params_comments.append(current_param)
+                current_param = ''
+            else:
+                current_param += param_char
+            if param_char == '[':
+                generic_nesting += 1
+            if param_char == ']':
+                generic_nesting -= 1
+        if current_param:
+            params_comments.append(current_param)
+        # If the number of parameters doesn't match length of type comment,
+        # ignore first parameter (assume it's self or cls).
+        if len(params_comments) != len(all_params):
+            all_params = all_params[1:]
+        # Find the specific param being investigated
+        index = all_params.index(param)
+        param_comment = params_comments[index]
+        # Construct annotation from type comment
+        annotation = tree.String(
+            repr(str(param_comment.strip())),
+            node.start_pos)
+        annotation.parent = node.parent
     module_context = execution_context.get_root_context()
     return _evaluate_for_annotation(module_context, annotation)
 
@@ -103,6 +147,19 @@ def py__annotations__(funcdef):
 @memoize_default()
 def infer_return_types(function_context):
     annotation = py__annotations__(function_context.tree_node).get("return", None)
+    if annotation is None:
+        # If there is no Python 3-type annotation, look for a Python 2-type annotation
+        node = function_context.tree_node
+        comment = parser_utils.get_following_comment_same_line(node)
+        if comment is None:
+            return []
+        match = re.match(r"^#\s*type:\s*\([^#]*\)\s*->\s*([^#]*)", comment)
+        if not match:
+            return []
+        annotation = tree.String(
+            repr(str(match.group(1).strip())),
+            node.start_pos)
+        annotation.parent = node.parent
     module_context = function_context.get_root_context()
     return _evaluate_for_annotation(module_context, annotation)
 

--- a/jedi/parser_utils.py
+++ b/jedi/parser_utils.py
@@ -200,6 +200,9 @@ def get_following_comment_same_line(node):
             whitespace = node.children[5].get_first_leaf().prefix
         elif node.type == 'with_stmt':
             whitespace = node.children[3].get_first_leaf().prefix
+        elif node.type == 'funcdef':
+            # actually on the next line
+            whitespace = node.children[4].get_first_leaf().get_next_leaf().prefix
         else:
             whitespace = node.get_last_leaf().get_next_leaf().prefix
     except AttributeError:

--- a/test/completion/pep0484_comments.py
+++ b/test/completion/pep0484_comments.py
@@ -51,7 +51,7 @@ class Employee:
 # following tests.
 # python >= 2.7
 
-from typing import List
+from typing import List, Tuple
 x = []   # type: List[Employee]
 #? Employee()
 x[1]
@@ -107,3 +107,35 @@ aaa = some_extremely_long_function_name_that_doesnt_leave_room_for_hints() \
     # type: float # We should be able to put hints on the next line with a \
 #? float()
 aaa
+
+# Test instance methods
+class Dog:
+    def __init__(self, age, friends, name):
+        # type: (int, List[Tuple[str, Dog]], str) -> None
+        self.age = age
+        self.friends = friends
+        self.name = name
+
+    def friend_for_name(self, name):
+        # type: (str) -> Dog
+        for (friend_name, friend) in self.friends:
+            if friend_name == name:
+                return friend
+        raise ValueError()
+
+    def bark(self): pass
+
+buddy = Dog(1, [('buster', Dog(1, [], 'buster'))], 9)
+friend = buddy.friend_for_name('buster')
+# type of friend is determined by function return type
+#! 9 ['def bark']
+friend.bark()
+
+friend = buddy.friends[0][1]
+# type of friend is determined by function parameter type
+#! 9 ['def bark']
+friend.bark()
+
+# type is determined by function parameter type following nested generics
+#? str()
+friend.name

--- a/test/test_evaluate/test_annotations.py
+++ b/test/test_evaluate/test_annotations.py
@@ -66,10 +66,12 @@ def test_function_param_annotations():
     """
     source = dedent("""\
     class Dog(object):
-        def __init__(self, name):
-            # type: (str) -> None
+        def __init__(self, age, friends, name):
+            # type: (int, List[Dog], str) -> None
+            self.age = age
+            self.friends = friends
             self.name = name
-    d = Dog(5)
+    d = Dog(5, [], 10)
     d.name""")
 
     assert [d.name for d in jedi.Script(source, ).goto_definitions()] == ['str']

--- a/test/test_evaluate/test_annotations.py
+++ b/test/test_evaluate/test_annotations.py
@@ -58,3 +58,44 @@ def test_lambda_forward_references():
     # For now just receiving the 3 is ok. I'm doubting that this is what we
     # want. We also execute functions. Should we only execute classes?
     assert jedi.Script(source).goto_definitions()
+
+
+def test_function_param_annotations():
+    """
+    Function annotation comments in Python 2, from PEP0484.
+    """
+    source = dedent("""\
+    class Dog(object):
+        def __init__(self, name):
+            # type: (str) -> None
+            self.name = name
+    d = Dog(5)
+    d.name""")
+
+    assert [d.name for d in jedi.Script(source, ).goto_definitions()] == ['str']
+
+
+def test_function_retval_annotations():
+    """
+    Function annotation comments for return values
+    """
+    source = dedent("""\
+    def annot():
+        # type: () -> str
+        pass
+
+    annot()""")
+
+    assert [d.name for d in jedi.Script(source, ).goto_definitions()] == ['str']
+
+
+def test_inline_comment_annotations():
+    """
+    Variable assignments may have type annotations inline.
+    """
+    source = dedent("""\
+    x = 5  # type: str
+
+    x""")
+
+    assert [d.name for d in jedi.Script(source, ).goto_definitions()] == ['str']


### PR DESCRIPTION
Addressing issue 946 (https://github.com/davidhalter/jedi/issues/946).
Enable one-line function type annotations in comments, per https://www.python.org/dev/peps/pep-0484/.

These annotations determine the types of variables which are parameters or return values of functions, allowing better code navigation to instance methods.