### PR TITLE
Fix get_line_code method.

### DIFF
--- a/jedi/api/classes.py
+++ b/jedi/api/classes.py
@@ -391,9 +391,9 @@ class BaseDefinition(object):
         path = self._name.get_root_context().py__file__()
         lines = parser_cache[path].lines
 
-        line_nr = self._name.start_pos[0]
-        start_line_nr = line_nr - before
-        return ''.join(lines[start_line_nr:line_nr + after + 1])
+        start = self._name.start_pos[0] - 1
+        start = 0 if start - before < 0 else start - before
+        return ''.join(lines[start:start + after + 1])
 
 
 class Completion(BaseDefinition):


### PR DESCRIPTION
Problem: `get_line_code` returns the wrong line of code.

Fix: make sure line numbers start at 0 when used as list indices. Also, make sure to prevent negative indices.