### PR TITLE
Resolve parameters of Compiled Object uniformly 

### DIFF
--- a/jedi/evaluate/helpers.py
+++ b/jedi/evaluate/helpers.py
@@ -147,6 +147,26 @@ def get_module_names(module, all_scopes):
     return names
 
 
+class FakeName(tree.Name):
+    def __init__(self, name_str, parent=None, start_pos=(0, 0), is_definition=None):
+        """
+        In case is_definition is defined (not None), that bool value will be
+        returned.
+        """
+        super(FakeName, self).__init__(name_str, start_pos)
+        self.parent = parent
+        self._is_definition = is_definition
+
+    def get_definition(self):
+        return self.parent
+
+    def is_definition(self):
+        if self._is_definition is None:
+            return super(FakeName, self).is_definition()
+        else:
+            return self._is_definition
+
+
 @contextmanager
 def predefine_names(context, flow_scope, dct):
     predefined = context.predefined_names

--- a/test/completion/named_param.py
+++ b/test/completion/named_param.py
@@ -58,5 +58,5 @@ Test().test(blub=)
 
 # builtins
 
-#? 12 []
+#? 12 ['iterable']
 any(iterable=)

--- a/test/test_api/test_interpreter.py
+++ b/test/test_api/test_interpreter.py
@@ -198,7 +198,7 @@ def test_param_completion():
 
     _assert_interpreter_complete('foo(bar', locals(), ['bar'])
 
-    if sys.version_info >= (3, 5):
+    if sys.version_info >= (3, 3):
         _assert_interpreter_complete('lambd(xyz', locals(), ['xyz'])
     else:
         _assert_interpreter_complete('lambd(xyz', locals(), [])

--- a/test/test_api/test_interpreter.py
+++ b/test/test_api/test_interpreter.py
@@ -2,6 +2,7 @@
 Tests of ``jedi.api.Interpreter``.
 """
 
+import sys
 from ..helpers import TestCase
 import jedi
 from jedi._compatibility import is_py33
@@ -196,5 +197,8 @@ def test_param_completion():
     lambd = lambda xyz: 3
 
     _assert_interpreter_complete('foo(bar', locals(), ['bar'])
-    # TODO we're not yet using the Python3.5 inspect.signature, yet.
-    assert not jedi.Interpreter('lambd(xyz', [locals()]).completions()
+
+    if sys.version_info >= (3, 5):
+        _assert_interpreter_complete('lambd(xyz', locals(), ['xyz'])
+    else:
+        _assert_interpreter_complete('lambd(xyz', locals(), [])


### PR DESCRIPTION
The previous version when resolving the parameters of  `print` for example, would return the default values because UnresolvableParamName just holds the name of a parameter.

So I brought back `jedi.evaluate.helpers.FakeName` and build a "proper" `ParamName` when returning the parameters of a CompiledObject; so the users of the library can have objects with the same "shape" and can analyze default parameters, `star_count` and it doesn't matter if the object is compiled or not.