### PR TITLE
citing autocomplete-python-jedi

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ Jedi can currently be used with the following editors/projects:
 - TextMate_ (Not sure if it's actually working)
 - Kate_ version 4.13+ supports it natively, you have to enable it, though. [`proof
   <https://projects.kde.org/projects/kde/applications/kate/repository/show?rev=KDE%2F4.13>`_]
-- Atom_ (autocomplete-python-jedi_, autocomplete-python_)
+- Atom_ (autocomplete-python-jedi_)
 - SourceLair_
 - `GNOME Builder`_ (with support for GObject Introspection)
 - `Visual Studio Code`_ (via `Python Extension <https://marketplace.visualstudio.com/items?itemName=donjayamanne.python>`_)
@@ -208,7 +208,6 @@ Acknowledgements
 .. _Kate: http://kate-editor.org
 .. _Atom: https://atom.io/
 .. _autocomplete-python-jedi: https://atom.io/packages/autocomplete-python-jedi
-.. _autocomplete-python: https://atom.io/packages/autocomplete-python
 .. _SourceLair: https://www.sourcelair.com
 .. _GNOME Builder: https://wiki.gnome.org/Apps/Builder
 .. _Visual Studio Code: https://code.visualstudio.com/

--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ Jedi can currently be used with the following editors/projects:
 - TextMate_ (Not sure if it's actually working)
 - Kate_ version 4.13+ supports it natively, you have to enable it, though. [`proof
   <https://projects.kde.org/projects/kde/applications/kate/repository/show?rev=KDE%2F4.13>`_]
-- Atom_ (autocomplete-python_)
+- Atom_ (autocomplete-python-jedi_, autocomplete-python_)
 - SourceLair_
 - `GNOME Builder`_ (with support for GObject Introspection)
 - `Visual Studio Code`_ (via `Python Extension <https://marketplace.visualstudio.com/items?itemName=donjayamanne.python>`_)
@@ -207,6 +207,7 @@ Acknowledgements
 .. _TextMate: https://github.com/lawrenceakka/python-jedi.tmbundle
 .. _Kate: http://kate-editor.org
 .. _Atom: https://atom.io/
+.. _autocomplete-python-jedi: https://atom.io/packages/autocomplete-python-jedi
 .. _autocomplete-python: https://atom.io/packages/autocomplete-python
 .. _SourceLair: https://www.sourcelair.com
 .. _GNOME Builder: https://wiki.gnome.org/Apps/Builder

--- a/docs/docs/usage.rst
+++ b/docs/docs/usage.rst
@@ -53,6 +53,7 @@ Visual Studio Code:
 - `Python Extension`_
 
 Atom:
+
 - autocomplete-python-jedi_
 - autocomplete-python_
 

--- a/docs/docs/usage.rst
+++ b/docs/docs/usage.rst
@@ -53,7 +53,7 @@ Visual Studio Code:
 - `Python Extension`_
 
 Atom:
-
+- autocomplete-python-jedi_
 - autocomplete-python_
 
 SourceLair:
@@ -114,6 +114,7 @@ Using a custom ``$HOME/.pythonrc.py``
 .. _wdb: https://github.com/Kozea/wdb
 .. _TextMate: https://github.com/lawrenceakka/python-jedi.tmbundle
 .. _kate: http://kate-editor.org/
+.. _autocomplete-python-jedi: https://atom.io/packages/autocomplete-python-jedi
 .. _autocomplete-python: https://atom.io/packages/autocomplete-python
 .. _SourceLair: https://www.sourcelair.com
 .. _GNOME Builder: https://wiki.gnome.org/Apps/Builder/

--- a/docs/docs/usage.rst
+++ b/docs/docs/usage.rst
@@ -55,7 +55,6 @@ Visual Studio Code:
 Atom:
 
 - autocomplete-python-jedi_
-- autocomplete-python_
 
 SourceLair:
 
@@ -116,7 +115,6 @@ Using a custom ``$HOME/.pythonrc.py``
 .. _TextMate: https://github.com/lawrenceakka/python-jedi.tmbundle
 .. _kate: http://kate-editor.org/
 .. _autocomplete-python-jedi: https://atom.io/packages/autocomplete-python-jedi
-.. _autocomplete-python: https://atom.io/packages/autocomplete-python
 .. _SourceLair: https://www.sourcelair.com
 .. _GNOME Builder: https://wiki.gnome.org/Apps/Builder/
 .. _gedi: https://github.com/isamert/gedi


### PR DESCRIPTION
Hi,

I modified the REAME.rst and usage.rst to cite also [autocomplete-python-jedi](https://atom.io/packages/autocomplete-python-jedi)  as a plugin for Atom.
It's a fork created following the [issues](https://github.com/autocomplete-python/autocomplete-python/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20refactor%20OR%20owner%20OR%20telemetry%20) that `autocomplete-python` has with [kite](https://kite.com).

The only political choice I've made is to list `autocomplete-python-jedi` before `autocomplete-python`.

best