### PR TITLE
Make goto work with await

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -44,6 +44,7 @@ Mathias Rav (@Mortal) <rav@cs.au.dk>
 Daniel Fiterman (@dfit99) <fitermandaniel2@gmail.com>
 Simon Ruggier (@sruggier)
 Élie Gouzien (@ElieGouzien)
-
+Robin Roth (@robinro)
+Malte Plath (@langsamer)
 
 Note: (@user) means a github user name.

--- a/jedi/evaluate/__init__.py
+++ b/jedi/evaluate/__init__.py
@@ -249,6 +249,8 @@ class Evaluator(object):
                 else:
                     i = trailer.parent.children.index(trailer)
                     to_evaluate = trailer.parent.children[:i]
+                    if to_evaluate[0] == 'await':
+                        to_evaluate.pop(0)
                     context_set = context.eval_node(to_evaluate[0])
                     for trailer in to_evaluate[1:]:
                         context_set = eval_trailer(context, context_set, trailer)

--- a/jedi/evaluate/helpers.py
+++ b/jedi/evaluate/helpers.py
@@ -89,6 +89,10 @@ def evaluate_call_of_leaf(context, leaf, cut_own_trailer=False):
         base = power.children[0]
         trailers = power.children[1:cut]
 
+    if base == 'await':
+        base = trailers[0]
+        trailers = trailers[1:]
+
     values = context.eval_node(base)
     from jedi.evaluate.syntax_tree import eval_trailer
     for trailer in trailers:

--- a/test/completion/async_.py
+++ b/test/completion/async_.py
@@ -23,3 +23,14 @@ async def x2():
     async with open('asdf') as f:
         #? ['readlines']
         f.readlines
+
+class A():
+    @staticmethod
+    async def b(c=1, d=2):
+        return 1
+
+#! 9 ['def b']
+await A.b()
+
+#! 11 ['param d=2']
+await A.b(d=3)


### PR DESCRIPTION
Goto on 
`await foo()` and `await foo(b=1)` didn't work and generated the following traceback:

```
Traceback (most recent call last):
  File "/foo/jedi-vim/pythonx/jedi_vim.py", line 128, in wrapper
    return func(*args, **kwargs)
  File "/foo/jedi-vim/pythonx/jedi_vim.py", line 240, in goto
    definitions = [x for x in script.goto_definitions()
  File "/foo/jedi-vim/pythonx/jedi/jedi/api/__init__.py", line 203, in goto_definitions 
    definitions = helpers.evaluate_goto_definition(self._evaluator, context, leaf)
  File "/foo/jedi-vim/pythonx/jedi/jedi/api/helpers.py", line 198, in evaluate_goto_definition
    return evaluator.goto_definitions(context, leaf)
  File "/foo/jedi-vim/pythonx/jedi/jedi/evaluate/__init__.py", line 462, in goto_definitions 
    return helpers.evaluate_call_of_leaf(context, name)
  File "/foo/jedi-vim/pythonx/jedi/jedi/evaluate/helpers.py", line 76, in evaluate_call_of_leaf
    values = context.eval_trailer(values, trailer)
  File "/foo/jedi-vim/pythonx/jedi/jedi/_compatibility.py", line 213, in <lambda>
    return lambda *args, **kwargs: self.func(obj, *args, **kwargs)
  File "/foo/jedi-vim/pythonx/jedi/jedi/evaluate/context.py", line 44, in eval_trailer 
    return self.evaluator.eval_trailer(self, types, trailer)
  File "/foo/jedi-vim/pythonx/jedi/jedi/evaluate/__init__.py", line 394, in eval_trailer
    trailer_op, node = trailer.children[:2]
AttributeError: 'Name' object has no attribute 'children'
```

This PR ignores `await` for goto and thereby jumps to the function definition or right argument.