### PR TITLE
Docstring for evaluate_call_of_leaf

### DIFF
--- a/jedi/evaluate/helpers.py
+++ b/jedi/evaluate/helpers.py
@@ -58,8 +58,11 @@ def evaluate_call_of_leaf(context, leaf, cut_own_trailer=False):
 
     If you're using the leaf, e.g. the bracket `)` it will return ``list([])``.
 
-    # TODO remove cut_own_trailer option, since its always used with it. Just
-    #      ignore it, It's not what we want anyway. Or document it better?
+    We use this function for two purposes. Given an expression ``bar.foo``,
+    we may want to
+      - infer the type of ``foo`` to offer completions after foo
+      - infer the type of ``bar`` to be able to jump to the definition of foo
+    The option ``cut_own_trailer`` must be set to true for the second purpose.
     """
     trailer = leaf.parent
     # The leaf may not be the last or first child, because there exist three


### PR DESCRIPTION
Hi David,

I removed the TODO about the optional parameter 'cut_own_trailer' because it really is needed. In its place I wrote an explanation when this parameter must be set to True.  (... which I hope is correct and clear)
The two commits in thist PR are identical in content; they stem from my difficulty grasping how forking and upstream branches work.  (Even that lesson made the sprint worth while for me ;-) )

Cheers,
Malte