### PR TITLE
Including ahead of time annotations 

### DIFF
--- a/test/completion/pep0484_aheadoftime.py
+++ b/test/completion/pep0484_aheadoftime.py
@@ -1,0 +1,34 @@
+""" Pep-0484 type hinting with ahead of time annotations """
+
+# python >= 3.6
+
+somelist = [1, 2, 3, "A", "A"]
+element : int
+for element in somelist[0:3]:
+    #? int()
+    element
+
+
+otherlist = [1, "A"]
+for e in otherlist:
+    #? int() str()
+    e
+
+
+test_string: str = "Hello, world!"
+#? str()
+test_string
+
+
+char: str
+for char in test_string:
+    #? str()
+    char
+
+
+import numpy
+somearrays = [numpy.ones((10, 10)), numpy.eye(10), 2, 2.3]
+array : numpy.ndarray
+for array in somearrays[0:2]:
+    #? numpy.ndarray()
+    array


### PR DESCRIPTION
In response to issue #974 we worked on including ahead of time annotations together at the Pycon.de sprint.

While the 5 tests I defined all pass, it seems like the code breaks some existing tests. I got **100+ failures** running `py.test test/test_integration.py`. Could this be a python version issue?