### PR TITLE
[WIP] Support async/await syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,9 @@ matrix:
     - env: TOXENV=cov
     - env: TOXENV=sith
   include:
-    - python: 3.5
+    - python: 3.6
       env: TOXENV=cov
-    - python: 3.5
+    - python: 3.6
       env: TOXENV=sith
 install:
     - pip install --quiet tox-travis

--- a/jedi/evaluate/base_context.py
+++ b/jedi/evaluate/base_context.py
@@ -63,10 +63,13 @@ class Context(BaseContext):
         arguments = ValuesArguments([ContextSet(value) for value in value_list])
         return self.execute(arguments)
 
-    def iterate(self, contextualized_node=None):
+    def iterate(self, contextualized_node=None, is_async=False):
         debug.dbg('iterate')
         try:
-            iter_method = self.py__iter__
+            if is_async:
+                iter_method = self.py__aiter__
+            else:
+                iter_method = self.py__iter__
         except AttributeError:
             if contextualized_node is not None:
                 from jedi.evaluate import analysis
@@ -241,9 +244,9 @@ class ContextSet(BaseContextSet):
     def py__class__(self):
         return ContextSet.from_iterable(c.py__class__() for c in self._set)
 
-    def iterate(self, contextualized_node=None):
+    def iterate(self, contextualized_node=None, is_async=False):
         from jedi.evaluate.lazy_context import get_merged_lazy_context
-        type_iters = [c.iterate(contextualized_node) for c in self._set]
+        type_iters = [c.iterate(contextualized_node, is_async=is_async) for c in self._set]
         for lazy_contexts in zip_longest(*type_iters):
             yield get_merged_lazy_context(
                 [l for l in lazy_contexts if l is not None]

--- a/jedi/evaluate/context/function.py
+++ b/jedi/evaluate/context/function.py
@@ -63,11 +63,19 @@ class FunctionContext(use_metaclass(CachedMetaClass, TreeContext)):
         """
         Created to be used by inheritance.
         """
-        yield_exprs = get_yield_exprs(self.evaluator, self.tree_node)
-        if yield_exprs:
-            return ContextSet(iterable.Generator(self.evaluator, function_execution))
+        is_coroutine = self.tree_node.parent.type == 'async_stmt'
+        is_generator = bool(get_yield_exprs(self.evaluator, self.tree_node))
+
+        if is_coroutine:
+            if is_generator:
+                return ContextSet(iterable.AsyncGenerator(self.evaluator, function_execution))
+            else:
+                return ContextSet(iterable.Coroutine(self.evaluator, function_execution))
         else:
-            return function_execution.get_return_values()
+            if is_generator:
+                return ContextSet(iterable.Generator(self.evaluator, function_execution))
+            else:
+                return function_execution.get_return_values()
 
     def get_function_execution(self, arguments=None):
         if arguments is None:
@@ -169,7 +177,8 @@ class FunctionExecutionContext(TreeContext):
             yield LazyTreeContext(self, node)
 
     @recursion.execution_recursion_decorator(default=iter([]))
-    def get_yield_values(self):
+    def get_yield_values(self, is_async=False):
+	# TODO: if is_async, wrap yield statements in Awaitable/async_generator_asend
         for_parents = [(y, tree.search_ancestor(y, 'for_stmt', 'funcdef',
                                                 'while_stmt', 'if_stmt'))
                        for y in get_yield_exprs(self.evaluator, self.tree_node)]

--- a/test/completion/async_.py
+++ b/test/completion/async_.py
@@ -6,17 +6,39 @@ raise errors or return extremely strange results.
 """
 
 async def x():
+    return 1
+
+#? []
+x.cr_awai
+
+#? ['cr_await']
+x().cr_awai
+
+a = await x()
+#? int()
+a
+
+async def y():
     argh = await x()
-    #? 
+    #? int()
     argh
     return 2
 
-#? int()
-x()
+async def asgen():
+    yield 1
+    await asyncio.sleep(0)
+    yield 2
 
-a = await x()
-#?
-a
+async def wrapper():
+    #? int()
+    [x async for x in asgen()][0]
+
+    async for y in asgen():
+        # TODO: make this an int()
+        y
+
+#? ['__anext__']
+asgen().__ane
 
 
 async def x2():


### PR DESCRIPTION
Improve support for async/await syntax.

This is still work in progress. 

TODO:
* [x] support for coroutines (async def): `async def a(): pass`
* [x] support for calling coroutines (await): `a` is function, `a()` is coroutine, `await a()` is return type
* [x] rough support for async generators, only working usecase so far:
```
async def foo():
    yield 1
a = [x async for x in foo()]
```
* [ ] correctly deal with async generators (return awaitable/async_generator_asend instead of values)
* [ ] figure out how to parse async/await types from python < 3.5/3.6, the `types` module only has the right types in 3.5 and 3.6; or at least give a better error than the current `ImportError`
* [ ] refactor coroutine/asyncgenerator to reuse code of generator/...; maybe move `Coroutine` to `function.py`

Fully supporting all async syntax is outside the scope of this PR. I opened an issue to track the progress: #985

