### PR TITLE
Support mypy annotations using Python 2 comment syntax

### DIFF
--- a/docs/docs/features.rst
+++ b/docs/docs/features.rst
@@ -47,8 +47,7 @@ Supported Python Features
 - (nested) list comprehensions / ternary expressions
 - relative imports
 - ``getattr()`` / ``__getattr__`` / ``__getattribute__``
-- function annotations (py3k feature, are ignored right now, but being parsed.
-  I don't know what to do with them.)
+- function annotations
 - class decorators (py3k feature, are being ignored too, until I find a use
   case, that doesn't work with |jedi|)
 - simple/usual ``sys.path`` modifications
@@ -116,8 +115,7 @@ one of the following docstring/annotation syntax styles:
 
 https://www.python.org/dev/peps/pep-0484/
 
-function annotations (Python 3 only; Python 2 function annotations with
-comments in planned but not yet implemented)
+function annotations (both Python 3 and Python 2 annotation syntax)
 
 ::
 

--- a/jedi/parser_utils.py
+++ b/jedi/parser_utils.py
@@ -201,6 +201,9 @@ def get_following_comment_same_line(node):
             whitespace = node.children[5].get_first_leaf().prefix
         elif node.type == 'with_stmt':
             whitespace = node.children[3].get_first_leaf().prefix
+        elif node.type == 'funcdef':
+            # actually on the next line
+            whitespace = node.children[4].get_first_leaf().get_next_leaf().prefix
         else:
             whitespace = node.get_last_leaf().get_next_leaf().prefix
     except AttributeError:

--- a/test/completion/pep0484_comments.py
+++ b/test/completion/pep0484_comments.py
@@ -47,7 +47,7 @@ b
 class Employee:
     pass
 
-from typing import List
+from typing import List, Tuple
 x = []   # type: List[Employee]
 #? Employee()
 x[1]
@@ -103,3 +103,81 @@ aaa = some_extremely_long_function_name_that_doesnt_leave_room_for_hints() \
     # type: float # We should be able to put hints on the next line with a \
 #? float()
 aaa
+
+# Test instance methods
+class Dog:
+    def __init__(self, age, friends, name):
+        # type: (int, List[Tuple[str, Dog]], str) -> None
+        #? int()
+        self.age = age
+        self.friends = friends
+
+        #? Dog()
+        friends[0][1]
+
+        #? str()
+        self.name = name
+
+    def friend_for_name(self, name):
+        # type: (str) -> Dog
+        for (friend_name, friend) in self.friends:
+            if friend_name == name:
+                return friend
+        raise ValueError()
+
+    def bark(self):
+        pass
+
+buddy = Dog(UNKNOWN_NAME1, UNKNOWN_NAME2, UNKNOWN_NAME3)
+friend = buddy.friend_for_name('buster')
+# type of friend is determined by function return type
+#! 9 ['def bark']
+friend.bark()
+
+friend = buddy.friends[0][1]
+# type of friend is determined by function parameter type
+#! 9 ['def bark']
+friend.bark()
+
+# type is determined by function parameter type following nested generics
+#? str()
+friend.name
+
+# Mypy comment describing function return type.
+def annot():
+    # type: () -> str
+    pass
+
+#? str()
+annot()
+
+# Mypy variable type annotation.
+x = UNKNOWN_NAME2  # type: str
+
+#? str()
+x
+
+class Cat(object):
+    def __init__(self, age, friends, name):
+        # type: (int, List[Dog], str) -> None
+        self.age = age
+        self.friends = friends
+        self.name = name
+
+cat = Cat(UNKNOWN_NAME4, UNKNOWN_NAME5, UNKNOWN_NAME6)
+#? str()
+cat.name
+
+# Don't crash on malformed type comments on variables.
+woops = UNKNOWN_NAME7 # type: oops[
+
+#?
+woops
+
+# Don't crash on malformed return type comments.
+def woops2(x):
+    # type: (no_such_type) -> broken_syntax[1.."
+    return UNKNOWN_NAME8
+
+#?
+woops2()


### PR DESCRIPTION
This allows us to use mypy annotations for completion in Python 2.

This is based on #947, rebased on the latest master. I've also done my best to resolve @davidhalter's feedback on that PR. I've replaced the regexp parsing with a call to `parso.parse`, and moved the tests as suggested.

I haven't resolved the comment on `_fix_forward_reference` -- I'm not sure what's wrong with that function that needs fixing.

Closes #946.