### PR TITLE
Fix AttributeError when incorrectly using generators with variable-length arguments

### DIFF
--- a/jedi/evaluate/arguments.py
+++ b/jedi/evaluate/arguments.py
@@ -29,6 +29,8 @@ def try_iter_content(types, depth=0):
 
 class AbstractArguments(object):
     context = None
+    argument_node = None
+    trailer = None
 
     def eval_argument_clinic(self, parameters):
         """Uses a list with argument clinic information (see PEP 436)."""
@@ -197,7 +199,11 @@ class TreeArguments(AbstractArguments):
                 arguments = param.var_args
                 break
 
-        return [arguments.argument_node or arguments.trailer]
+        if arguments.argument_node:
+            return [arguments.argument_node]
+        if arguments.trailer:
+            return [arguments.trailer]
+        return []
 
 
 class ValuesArguments(AbstractArguments):

--- a/test/completion/decorators.py
+++ b/test/completion/decorators.py
@@ -211,6 +211,17 @@ class X():
         #?
         self.x()
 
+
+def decorator_var_args(function, *args):
+    return function(*args)
+
+@decorator_var_args
+def function_var_args(param):
+    return param
+
+#? int()
+function_var_args(1)
+
 # -----------------
 # method decorators
 # -----------------


### PR DESCRIPTION
Jedi raises the exception
```python
 File "jedi\evaluate\arguments.py", line 200, in get_calling_nodes
    return [arguments.argument_node or arguments.trailer]
AttributeError: 'ValuesArguments' object has no attribute 'argument_node'
```
when getting the definition of `function_var_args` in the following code
```python
def decorator_var_args(function, *args):
    return function(*args)

@decorator_var_args
def function_var_args(param):
    return param
```
This error was initially reported in https://github.com/vheon/JediHTTP/issues/51 and reduced to the code above.

While I don't fully understand the involved code in Jedi, I think the proposed fix makes sense (defining `argument_node` and `trailer` properties in the base class `AbstractArguments`) as `arguments` can be any object derived from `AbstractArguments` (`ValuesArguments` in that case) and not necessarily `TreeArguments`.

Added a test that fails without the fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/davidhalter/jedi/1026)
<!-- Reviewable:end -->
