### PR TITLE
Fix typo in docstring for imports.py

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -46,5 +46,6 @@ Simon Ruggier (@sruggier)
 Élie Gouzien (@ElieGouzien)
 Robin Roth (@robinro)
 Malte Plath (@langsamer)
+Anton Zub (@zabulazza)
 
 Note: (@user) means a github user name.

--- a/jedi/evaluate/imports.py
+++ b/jedi/evaluate/imports.py
@@ -9,7 +9,7 @@ This module uses imp for python up to 3.2 and importlib for python 3.3 on; the
 correct implementation is delegated to _compatibility.
 
 This module also supports import autocompletion, which means to complete
-statements like ``from datetim`` (curser at the end would return ``datetime``).
+statements like ``from datetim`` (cursor at the end would return ``datetime``).
 """
 import os
 


### PR DESCRIPTION
The intention of this pull request is to fix typo in imports.py