### PR TITLE
Fix for #1037 and Python 3 issues on Windows.

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -1,4 +1,4 @@
-Main Authors
+﻿Main Authors
 ============
 
 David Halter (@davidhalter) <davidhalter88@gmail.com>
@@ -48,5 +48,6 @@ Robin Roth (@robinro)
 Malte Plath (@langsamer)
 Anton Zub (@zabulazza)
 Maksim Novikov (@m-novikov) <mnovikov.work@gmail.com>
+Tobias Rzepka (@TobiasRzepka)
 
 Note: (@user) means a github user name.

--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -47,6 +47,5 @@ Simon Ruggier (@sruggier)
 Robin Roth (@robinro)
 Malte Plath (@langsamer)
 Anton Zub (@zabulazza)
-Tobias Rzepka (@TobiasRzepka)
 
 Note: (@user) means a github user name.

--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -47,5 +47,6 @@ Simon Ruggier (@sruggier)
 Robin Roth (@robinro)
 Malte Plath (@langsamer)
 Anton Zub (@zabulazza)
+Tobias Rzepka (@TobiasRzepka)
 
 Note: (@user) means a github user name.

--- a/jedi/evaluate/compiled/subprocess/__init__.py
+++ b/jedi/evaluate/compiled/subprocess/__init__.py
@@ -138,13 +138,11 @@ class _CompiledSubprocess(object):
             _MAIN_PATH,
             os.path.dirname(os.path.dirname(parso_path))
         )
-        universal_newlines = not is_py3
         return subprocess.Popen(
             args,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             # stderr=subprocess.PIPE
-            universal_newlines=universal_newlines
         )
 
     def run(self, evaluator, function, args=(), kwargs={}):

--- a/jedi/evaluate/compiled/subprocess/__init__.py
+++ b/jedi/evaluate/compiled/subprocess/__init__.py
@@ -138,11 +138,13 @@ class _CompiledSubprocess(object):
             _MAIN_PATH,
             os.path.dirname(os.path.dirname(parso_path))
         )
+        universal_newlines = not is_py3
         return subprocess.Popen(
             args,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             # stderr=subprocess.PIPE
+            universal_newlines=universal_newlines
         )
 
     def run(self, evaluator, function, args=(), kwargs={}):

--- a/jedi/evaluate/compiled/subprocess/__init__.py
+++ b/jedi/evaluate/compiled/subprocess/__init__.py
@@ -187,7 +187,6 @@ class _CompiledSubprocess(object):
         data = evaluator_id, function, args, kwargs
         try:
             pickle_dump(data, self._process.stdin)
-            self._process.stdin.flush()
         except (socket.error, IOError) as e:
             # Once Python2 will be removed we can just use `BrokenPipeError`.
             if e.errno != errno.EPIPE:
@@ -283,7 +282,6 @@ class Listener(object):
                 result = True, traceback.format_exc(), e
 
             pickle_dump(result, file=stdout)
-            stdout.flush()
 
 
 class AccessHandle(object):


### PR DESCRIPTION
Hello David,
this time it's looking better. All tox test run fine (at least 2 are broken on Windows but that are other issues). Main problem is the shell which consumes all control characters (below 32) and expand \n to \r\n. Not good, if binary data is transported. After that, if found out, that Python on Windows don't throw EPIPE and EOF errors for pipes. So I reraise them with the correct type / error number.
On Python 3.3 it was another special case, where the flush throws sometimes an error, where normally at the pickle dump it is thrown. So I shifted the flush also to _compatibility.py.

Tobias