### PR TITLE
Properly raise broken pipe exception

### DIFF
--- a/jedi/_compatibility.py
+++ b/jedi/_compatibility.py
@@ -490,7 +490,7 @@ def pickle_dump(data, file):
         # Python on Windows don't throw EPIPE errors for pipes. So reraise them with
         # the correct type and error number.
         except OSError:
-            raise IOError(errno.EPIPE)
+            raise IOError(errno.EPIPE, "Broken pipe")
     else:
         pickle.dump(data, file, protocol=_PICKLE_PROTOCOL)
         file.flush()


### PR DESCRIPTION
We need to pass an error message to the `IOError` exception in addition to the error number; otherwise, it is raised as a normal exception with the message `32` (`errno.EPIPE` being equal to `32`). See [the `EnvironmentError` docs](https://docs.python.org/2.7/library/exceptions.html#exceptions.EnvironmentError) (`IOError` is a subclass of `EnvironmentError` on Python 2) and [the `OSError` docs](https://docs.python.org/3.6/library/exceptions.html#OSError) (`IOError` is an alias of `OSError` on Python 3).