### PR TITLE
Do not cache unimportable compiled module

### DIFF
--- a/jedi/evaluate/imports.py
+++ b/jedi/evaluate/imports.py
@@ -500,19 +500,21 @@ def _load_module(evaluator, path=None, code=None, sys_path=None,
             )
         else:
             module = compiled.load_module(evaluator, path=path, sys_path=sys_path)
-    add_module(evaluator, module_name, module, safe=safe_module_name)
+
+    if module_name is not None and module is not None:
+        add_module(evaluator, module_name, module, safe=safe_module_name)
+
     return module
 
 
 def add_module(evaluator, module_name, module, safe=False):
-    if module_name is not None:
-        if not safe and '.' not in module_name:
-            # We cannot add paths with dots, because that would collide with
-            # the sepatator dots for nested packages. Therefore we return
-            # `__main__` in ModuleWrapper.py__name__(), which is similar to
-            # Python behavior.
-            return
-        evaluator.module_cache.add(module, module_name)
+    if not safe and '.' not in module_name:
+        # We cannot add paths with dots, because that would collide with
+        # the sepatator dots for nested packages. Therefore we return
+        # `__main__` in ModuleWrapper.py__name__(), which is similar to
+        # Python behavior.
+        return
+    evaluator.module_cache.add(module, module_name)
 
 
 def get_modules_containing_name(evaluator, modules, name):


### PR DESCRIPTION
Jedi attempts to cache a compiled module even if it failed to import it, resulting in the following error when trying to get the description of that module:
```
Traceback (most recent call last):
  File "script.py", line 26, in <module>
    completions[0].description
  File "jedi\jedi\api\classes.py", line 464, in description
    return Definition.description.__get__(self)
  File "jedi\jedi\api\classes.py", line 519, in description
    typ = self.type
  File "jedi\jedi\api\classes.py", line 146, in type
    for context in self._name.infer():
  File "jedi\jedi\evaluate\imports.py", line 172, in infer
    level=self._level,
  File "jedi\jedi\evaluate\imports.py", line 279, in follow
    return self._do_import(self.import_path, self.sys_path_with_modifications())
  File "jedi\jedi\evaluate\imports.py", line 367, in _do_import
    safe_module_name=True,
  File "jedi\jedi\evaluate\imports.py", line 503, in _load_module
    add_module(evaluator, module_name, module, safe=safe_module_name)
  File "jedi\jedi\evaluate\imports.py", line 515, in add_module
    evaluator.module_cache.add(module, module_name)
  File "jedi\jedi\evaluate\imports.py", line 40, in add
    path = module.py__file__()
AttributeError: 'NoneType' object has no attribute 'py__file__'
```
The issue can be reproduced by getting the description of the `QtBluetooth` module from [`PyQt5`](https://pypi.python.org/pypi/PyQt5) on Windows:
```python
import jedi
completions = jedi.Script('import PyQt5.QtBlueTooth').completions()
completions[0].description
```
The fix is to simply not cache the module in that case.

I'd like to add a test for this but it's tricky to do since this occurs with compiled modules and the reproducible case is specific to Windows. Any suggestions?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/davidhalter/jedi/1079)
<!-- Reviewable:end -->
