### PR TITLE
Fix virtual environment tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,12 @@ env:
   - JEDI_TEST_ENVIRONMENT=35
   - JEDI_TEST_ENVIRONMENT=36
 
+addons:
+  apt:
+    packages:
+     # Required to properly create a virtual environment with system Python 3.4.
+     - python3.4-venv
+
 matrix:
   allow_failures:
     - python: pypy
@@ -39,8 +45,6 @@ before_install:
     # something twice, but it doesn't really matter, because they are appended.
     - export PATH=$PATH:/opt/python/3.3/bin
     - export PATH=$PATH:/opt/python/3.5/bin
-    # 3.6 was not installed manually, but already is on the system. However
-    # it's not on path (unless 3.6 is selected).
     - export PATH=$PATH:/opt/python/3.6/bin
 install:
     - pip install --quiet tox-travis

--- a/jedi/api/environment.py
+++ b/jedi/api/environment.py
@@ -239,14 +239,11 @@ def _get_executable_path(path, safe=True):
     """
 
     if os.name == 'nt':
-        bin_name = 'Scripts'
-        extension = '.exe'
+        activate = os.path.join(path, 'Scripts', 'activate.bat')
+        python = os.path.join(path, 'Scripts', 'python.exe')
     else:
-        bin_name = 'bin'
-        extension = ''
-    bin_folder = os.path.join(path, bin_name)
-    activate = os.path.join(bin_folder, 'activate')
-    python = os.path.join(bin_folder, 'python' + extension)
+        activate = os.path.join(path, 'bin', 'activate')
+        python = os.path.join(path, 'bin', 'python')
     if not all(os.path.exists(p) for p in (activate, python)):
         raise InvalidPythonEnvironment("One of bin/activate and bin/python is missing.")
 

--- a/travis_install.sh
+++ b/travis_install.sh
@@ -9,6 +9,14 @@ if [[ $JEDI_TEST_ENVIRONMENT == "35" ]]; then
     VERSION=3.5
     DOWNLOAD=1
 fi
+# 3.6 is already installed on Travis but not as root. This is problematic for
+# our virtualenv tests because we require the Python used to create a virtual
+# environment to be owned by root (or to be in a safe location which is not the
+# case here).
+if [[ $JEDI_TEST_ENVIRONMENT == "36" ]]; then
+    VERSION=3.6
+    DOWNLOAD=1
+fi
 
 if [[ -z $VERSION ]]; then
     echo "Environments should already be installed"


### PR DESCRIPTION
There were three issues:
 - on Windows, prior to Python 3.6, there is no `activate` file but only `activate.bat` in the `Scripts` folder when creating a virtual environment;
 - on Travis, system Python 3.4 cannot properly create a virtual environment. We need to install the `python3.4-venv` package;
 - on Travis again, the pre-installed Python 3.6 is not owned by root which makes it unsafe to use. We need to install it manually.