### PR TITLE
Extend create_environment to accept an executable path

### DIFF
--- a/jedi/api/environment.py
+++ b/jedi/api/environment.py
@@ -287,11 +287,15 @@ def get_system_environment(version):
 
 def create_environment(path, safe=True):
     """
-    Make it possible to create an environment by hand.
+    Make it possible to manually create an environment by specifying a
+    Virtualenv path or an executable path.
 
     :raises: :exc:`.InvalidPythonEnvironment`
     :returns: :class:`Environment`
     """
+    if os.path.isfile(path):
+        _assert_safe(path, safe)
+        return Environment(_get_python_prefix(path), path)
     return Environment(path, _get_executable_path(path, safe=safe))
 
 
@@ -307,8 +311,7 @@ def _get_executable_path(path, safe=True):
     if not os.path.exists(python):
         raise InvalidPythonEnvironment("%s seems to be missing." % python)
 
-    if safe and not _is_safe(python):
-        raise InvalidPythonEnvironment("The python binary is potentially unsafe.")
+    _assert_safe(python, safe)
     return python
 
 
@@ -337,6 +340,12 @@ def _get_executables_from_windows_registry(version):
                         yield prefix, exe
             except WindowsError:
                 pass
+
+
+def _assert_safe(executable_path, safe):
+    if safe and not _is_safe(executable_path):
+        raise InvalidPythonEnvironment(
+            "The python binary is potentially unsafe.")
 
 
 def _is_safe(executable_path):

--- a/test/test_api/test_environment.py
+++ b/test/test_api/test_environment.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from contextlib import contextmanager
 
 import pytest
@@ -6,7 +7,8 @@ import pytest
 import jedi
 from jedi._compatibility import py_version
 from jedi.api.environment import get_default_environment, find_virtualenvs, \
-    InvalidPythonEnvironment, find_system_environments, get_system_environment
+    InvalidPythonEnvironment, find_system_environments, \
+    get_system_environment, create_environment
 
 
 def test_sys_path():
@@ -111,3 +113,13 @@ def test_working_venv(venv_path):
 def test_scanning_venvs(venv_path):
     parent_dir = os.path.dirname(venv_path)
     assert any(venv.path == venv_path for venv in find_virtualenvs([parent_dir]))
+
+
+def test_create_environment_venv_path(venv_path):
+    environment = create_environment(venv_path)
+    assert environment.path == venv_path
+
+
+def test_create_environment_executable():
+    environment = create_environment(sys.executable)
+    assert environment.executable == sys.executable


### PR DESCRIPTION
There is currently no way to create an environment for a given executable path through the API. The `create_environment` function only accepts a path to a virtual environment. This PR extends that function to also accept executable paths.

@davidhalter I sent you an email about this but didn't get an answer. You probably missed it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/davidhalter/jedi/1088)
<!-- Reviewable:end -->
