### PR TITLE
Fix namespace autocompletion error

### DIFF
--- a/jedi/evaluate/context/namespace.py
+++ b/jedi/evaluate/context/namespace.py
@@ -3,24 +3,18 @@ from itertools import chain
 
 from jedi.evaluate.cache import evaluator_method_cache
 from jedi.evaluate import imports
-from jedi.evaluate.filters import DictFilter, AbstractNameDefinition
+from jedi.evaluate.filters import DictFilter, AbstractNameDefinition, ContextNameMixin
 from jedi.evaluate.base_context import TreeContext, ContextSet
 
 
-class ImplicitNSName(AbstractNameDefinition):
+class ImplicitNSName(ContextNameMixin, AbstractNameDefinition):
     """
     Accessing names for implicit namespace packages should infer to nothing.
     This object will prevent Jedi from raising exceptions
     """
     def __init__(self, implicit_ns_context, string_name):
-        self.parent_context = implicit_ns_context
+        self._context = implicit_ns_context
         self.string_name = string_name
-
-    def infer(self):
-        return ContextSet(self.parent_context)
-
-    def get_root_context(self):
-        return self.parent_context
 
 
 class ImplicitNamespaceContext(TreeContext):
@@ -56,9 +50,11 @@ class ImplicitNamespaceContext(TreeContext):
         """
         return self._fullname
 
-    @property
     def py__path__(self):
-        return lambda: [self.paths]
+        return [self.paths]
+
+    def py__name__(self):
+        return self._fullname
 
     @evaluator_method_cache()
     def _sub_modules_dict(self):

--- a/test/test_evaluate/test_implicit_namespace_package.py
+++ b/test/test_evaluate/test_implicit_namespace_package.py
@@ -93,3 +93,13 @@ def test_namespace_package_in_multiple_directories_goto_definition(Script):
     script = Script(sys_path=sys_path, source=CODE)
     result = script.goto_definitions()
     assert len(result) == 1
+
+
+def test_namespace_name_autocompletion_full_name(Script):
+    CODE = 'from pk'
+    sys_path = [join(dirname(__file__), d)
+                for d in ['implicit_namespace_package/ns1', 'implicit_namespace_package/ns2']]
+
+    script = Script(sys_path=sys_path, source=CODE)
+    compl = script.completions()
+    assert set(c.full_name for c in compl) == set(['pkg'])


### PR DESCRIPTION
When using calling full_name on namespace autocompletion error is raised
```
...
     for n in reversed(module_context.py__name__().split('.')):
AttributeError: 'ImplicitNamespaceContext' object has no attribute 'py__name__'
```
Also while fixing it found out that full_name for namespaces was build incorrectly.