### PR TITLE
Include stderr with "subprocess has crashed" exception

### DIFF
--- a/jedi/evaluate/compiled/subprocess/__init__.py
+++ b/jedi/evaluate/compiled/subprocess/__init__.py
@@ -204,16 +204,18 @@ class _CompiledSubprocess(object):
 
         try:
             is_exception, traceback, result = pickle_load(self._process.stdout)
-        except EOFError:
+        except EOFError as eof_error:
             try:
                 stderr = self._process.stderr.read()
             except Exception as exc:
                 stderr = '<empty/not available (%r)>' % exc
             self.kill()
-            raise InternalError("The subprocess %s has crashed (stderr=%s)." % (
-                self._executable,
-                stderr,
-            ))
+            raise InternalError(
+                "The subprocess %s has crashed (%r, stderr=%s)." % (
+                    self._executable,
+                    eof_error,
+                    stderr,
+                ))
 
         if is_exception:
             # Replace the attribute error message with a the traceback. It's


### PR DESCRIPTION
This does not add it to the other similar exception raised from `kill`,
since this should be something like "was killed already" anyway.

Fixes https://github.com/davidhalter/jedi/issues/1123.