### PR TITLE
Travis: do not use --quiet with `pip install`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 sudo: true
+cache: false
 python:
   - 2.7
   - 3.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,7 @@ before_install:
     # it's not on path (unless 3.6 is selected).
     - export PATH=$PATH:/opt/python/3.6/bin
 install:
+    - pip install -U pip
     - pip install tox-travis
 script:
     - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ before_install:
     # it's not on path (unless 3.6 is selected).
     - export PATH=$PATH:/opt/python/3.6/bin
 install:
-    - pip install --quiet tox-travis
+    - pip install tox-travis
 script:
     - tox
 after_script:


### PR DESCRIPTION
This drops any output including the version(s) that are installed.

Currently Python 3.3. builds appear to fail, because tox tries to install `wheel`?!

https://travis-ci.org/davidhalter/jedi/jobs/380136672#L577