### PR TITLE
Fix flow analysis test

### DIFF
--- a/test/completion/flow_analysis.py
+++ b/test/completion/flow_analysis.py
@@ -31,8 +31,8 @@ finally:
 
 if False:
     with open("") as defined_in_false:
-        #? ['seekable']
-        defined_in_false.seekab
+        #? ['flush']
+        defined_in_false.flu
 
 # -----------------
 # Return checks


### PR DESCRIPTION
There is [no `seekable` method for file objects on Python 2](https://docs.python.org/2/library/stdtypes.html#bltin-file-objects). Use `flush` instead which is available on both Python.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/davidhalter/jedi/1140)
<!-- Reviewable:end -->
