### PR TITLE
Use system default buffering on Python 2

### DIFF
--- a/jedi/evaluate/compiled/subprocess/__init__.py
+++ b/jedi/evaluate/compiled/subprocess/__init__.py
@@ -142,6 +142,9 @@ class _CompiledSubprocess(object):
             args,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
+            # Use system default buffering on Python 2 to improve performance
+            # (this is already the case on Python 3).
+            bufsize=-1
         )
 
     def run(self, evaluator, function, args=(), kwargs={}):


### PR DESCRIPTION
By default, streams are unbuffered on Python 2 (`bufsize = 0`) while system default buffering is used on Python 3 (`bufsize = -1`). Using system default buffering as well on Python 2 improves performance.

Here are some measurements obtained with [this script](https://gist.github.com/micbou/28eae3625de4820dac04b3b38ee0789b) when completing the `os`, `numpy`, and `cv2` ([opencv-python](https://pypi.org/project/opencv-python/)) modules on Python 2 and Ubuntu 18.04 64-bit: 

<table> 
  <tr>    
    <th>Environment</th>
    <th colspan="2">Python 2.7</th>
    <th colspan="2">Python 3.6</th>
  </tr>
  <tr>
    <th>bufsize</th>
    <th>0</th>
    <th>-1</th>
    <th>0</th>
    <th>-1</th>
  </tr>
  <tr>    
    <th>os</th>
    <td>0.145s</td>
    <td>0.102s</td>
    <td>0.162s</td>
    <td>0.104s</td>
  </tr>
  <tr>
    <th>numpy</th>
    <td>0.217s</td>
    <td>0.185s</td>
    <td>0.224s</td>
    <td>0.192s</td>
  </tr>
  <tr> 
    <th>cv2</th>
    <td>0.921s</td>
    <td>0.664s</td>
    <td>0.987s</td>
    <td>0.676s</td>
  </tr>  
</table>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/davidhalter/jedi/1149)
<!-- Reviewable:end -->
