### PR TITLE
Set stdout and stdin to binary mode on Python 2 and Windows

### DIFF
--- a/jedi/_compatibility.py
+++ b/jedi/_compatibility.py
@@ -2,7 +2,6 @@
 To ensure compatibility from Python ``2.7`` - ``3.x``, a module has been
 created. Clearly there is huge need to use conforming syntax.
 """
-import binascii
 import errno
 import sys
 import os
@@ -448,52 +447,33 @@ if sys.version_info[:2] == (3, 3):
 
 
 _PICKLE_PROTOCOL = 2
-is_windows = sys.platform == 'win32'
-
-# The Windows shell on Python 2 consumes all control characters (below 32) and expand on
-# all Python versions \n to \r\n.
-# pickle starting from protocol version 1 uses binary data, which could not be escaped by
-# any normal unicode encoder. Therefore, the only bytes encoder which doesn't produce
-# control characters is binascii.hexlify.
 
 
 def pickle_load(file):
-    if is_windows:
-        try:
-            data = file.readline()
-            data = binascii.unhexlify(data.strip())
-            if is_py3:
-                return pickle.loads(data, encoding='bytes')
-            else:
-                return pickle.loads(data)
-        # Python on Windows don't throw EOF errors for pipes. So reraise them with
-        # the correct type, which is cought upwards.
-        except OSError:
-            raise EOFError()
-    else:
+    try:
         if is_py3:
             return pickle.load(file, encoding='bytes')
-        else:
-            return pickle.load(file)
+        return pickle.load(file)
+    # Python on Windows don't throw EOF errors for pipes. So reraise them with
+    # the correct type, which is caught upwards.
+    except OSError:
+        if sys.platform == 'win32':
+            raise EOFError()
+        raise
 
 
 def pickle_dump(data, file):
-    if is_windows:
-        try:
-            data = pickle.dumps(data, protocol=_PICKLE_PROTOCOL)
-            data = binascii.hexlify(data)
-            file.write(data)
-            file.write(b'\n')
-            # On Python 3.3 flush throws sometimes an error even if the two file writes
-            # should done it already before. This could be also computer / speed depending.
-            file.flush()
-        # Python on Windows don't throw EPIPE errors for pipes. So reraise them with
-        # the correct type and error number.
-        except OSError:
-            raise IOError(errno.EPIPE, "Broken pipe")
-    else:
+    try:
         pickle.dump(data, file, protocol=_PICKLE_PROTOCOL)
+        # On Python 3.3 flush throws sometimes an error even though the writing
+        # operation should be completed.
         file.flush()
+    # Python on Windows don't throw EPIPE errors for pipes. So reraise them with
+    # the correct type and error number.
+    except OSError:
+        if sys.platform == 'win32':
+            raise IOError(errno.EPIPE, "Broken pipe")
+        raise
 
 
 try:

--- a/jedi/evaluate/compiled/subprocess/__init__.py
+++ b/jedi/evaluate/compiled/subprocess/__init__.py
@@ -278,6 +278,12 @@ class Listener(object):
         if sys.version_info[0] > 2:
             stdout = stdout.buffer
             stdin = stdin.buffer
+        # Python 2 opens streams in text mode on Windows. Set stdout and stdin
+        # to binary mode.
+        elif sys.platform == 'win32':
+            import msvcrt
+            msvcrt.setmode(stdout.fileno(), os.O_BINARY)
+            msvcrt.setmode(stdin.fileno(), os.O_BINARY)
 
         while True:
             try:


### PR DESCRIPTION
In PR https://github.com/davidhalter/jedi/pull/1046, a workaround was implemented on Windows to avoid control characters on stdin and stdout because those streams are open in text mode on Python 2. The workaround consists to convert the binary data to its hexadecimal representation. The issue with that approach is that it can be really inefficient when the data is big. A better solution is to put stdin and stdout in binary mode on Windows and Python 2.

Here are some measurements obtained with [this script](https://gist.github.com/micbou/28eae3625de4820dac04b3b38ee0789b) when completing the `os`, `numpy`, and `cv2` ([opencv-python](https://pypi.org/project/opencv-python/)) modules before and after the changes on Windows: 

<table>
  <tr>    
    <th>Interpreter</th>
    <th colspan="4">Python 2.7</th>
    <th colspan="4">Python 3.6</th>
  </tr>
  <tr>    
    <th rowspan="2">Environment</th>
    <th colspan="2">Python 2.7</th>
    <th colspan="2">Python 3.6</th>
    <th colspan="2">Python 2.7</th>
    <th colspan="2">Python 3.6</th>
  </tr>
  <tr>
    <td>Before</td>
    <td>After</td>
    <td>Before</td>
    <td>After</td>
    <td>Before</td>
    <td>After</td>
    <td>Before</td>
    <td>After</td>
  </tr>
  <tr>    
    <th>os</th>
    <td>0.111s</td>
    <td>0.141s</td>
    <td>0.088s</td>
    <td>0.13s</td>
    <td>0.062s</td>
    <td>0.062s</td>
    <td>0.04s</td>
    <td>0.041s</td>
  </tr>
  <tr>
    <th>numpy</th>
    <td>1.01s</td>
    <td>0.286s</td>
    <td>1.08s</td>
    <td>0.344s</td>
    <td>0.204s</td>
    <td>0.167s</td>
    <td>0.167s</td>
    <td>0.153s</td>
  </tr>
  <tr> 
    <th>cv2</th>
    <td>32.9s</td>
    <td>1.37s</td>
    <td>43.3s</td>
    <td>1.98s</td>
    <td>1.89s</td>
    <td>0.493s</td>
    <td>1.95s</td>
    <td>0.854s</td>
  </tr>  
</table>

As you can see, speed improvements are huge for the `cv2` module on Python 2 (up to 20 times faster). Only completing the os module on Python 2 is slower but the speed improvement in PR https://github.com/davidhalter/jedi/pull/1149 takes care of that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/davidhalter/jedi/1150)
<!-- Reviewable:end -->
