### PR TITLE
Use cPickle on Python 2 if available

### DIFF
--- a/jedi/_compatibility.py
+++ b/jedi/_compatibility.py
@@ -381,8 +381,12 @@ if is_py3:
 else:
     import Queue as queue
 
-
-import pickle
+try:
+    # Attempt to load the C implementation of pickle on Python 2 as it is way
+    # faster.
+    import cPickle as pickle
+except ImportError:
+    import pickle
 if sys.version_info[:2] == (3, 3):
     """
     Monkeypatch the unpickler in Python 3.3. This is needed, because the


### PR DESCRIPTION
We should use [the cPickle module](https://docs.python.org/2.7/library/pickle.html#module-cPickle) if available since it is a C implementation of pickle that is way faster.

Here are the difference between pickle and cPickle measured with [this script](https://gist.github.com/micbou/28eae3625de4820dac04b3b38ee0789b) when completing the `os`, `numpy`, and `cv2` ([opencv-python](https://pypi.org/project/opencv-python/)) modules on Ubuntu 18.04 64-bit: 

<table>
  <tr>    
    <th>Interpreter</th>
    <th colspan="4">Python 2.7</th>
    <th colspan="4">Python 3.6</th>
  </tr>
  <tr>    
    <th>Env.</th>
    <th colspan="2">Python 2.7</th>
    <th colspan="2">Python 3.6</th>
    <th colspan="2">Python 2.7</th>
    <th colspan="2">Python 3.6</th>
  </tr>
  <tr>
    <th>Module</th>
    <td>pickle</td>
    <td>cPickle</td>
    <td>pickle</td>
    <td>cPickle</td>
    <td>pickle</td>
    <td>cPickle</td>
    <td>pickle</td>
    <td>cPickle</td>
  </tr>
  <tr>    
    <th>os</th>
    <td>0.17s</td>
    <td>0.107s</td>
    <td>0.18s</td>
    <td>0.156s</td>
    <td>0.0946s</td>
    <td>0.0741s</td>
    <td>0.0738s</td>
    <td>0.0728s</td>
  </tr>
  <tr>
    <th>numpy</th>
    <td>0.245s</td>
    <td>0.199s</td>
    <td>0.261s</td>
    <td>0.242s</td>
    <td>0.209s</td>
    <td>0.184s</td>
    <td>0.181s</td>
    <td>0.179s</td>
  </tr>
  <tr> 
    <th>cv2</th>
    <td>0.924s</td>
    <td>0.652s</td>
    <td>1.05s</td>
    <td>0.932s</td>
    <td>0.519s</td>
    <td>0.355s</td>
    <td>0.471s</td>
    <td>0.47s</td>
  </tr>  
</table>

We can see a significant improvement for all combinations of Python except when the interpreter running Jedi and the environment are both Python 3 (which is expected since there is no cPickle on Python 3).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/davidhalter/jedi/1151)
<!-- Reviewable:end -->
