### PR TITLE
Use highest possible pickle protocol

### DIFF
--- a/jedi/_compatibility.py
+++ b/jedi/_compatibility.py
@@ -446,9 +446,6 @@ if sys.version_info[:2] == (3, 3):
     pickle.loads = loads
 
 
-_PICKLE_PROTOCOL = 2
-
-
 def pickle_load(file):
     try:
         if is_py3:
@@ -462,9 +459,9 @@ def pickle_load(file):
         raise
 
 
-def pickle_dump(data, file):
+def pickle_dump(data, file, protocol):
     try:
-        pickle.dump(data, file, protocol=_PICKLE_PROTOCOL)
+        pickle.dump(data, file, protocol)
         # On Python 3.3 flush throws sometimes an error even though the writing
         # operation should be completed.
         file.flush()
@@ -474,6 +471,20 @@ def pickle_dump(data, file):
         if sys.platform == 'win32':
             raise IOError(errno.EPIPE, "Broken pipe")
         raise
+
+
+# Determine the highest protocol version compatible for a given list of Python
+# versions.
+def highest_pickle_protocol(python_versions):
+    protocol = 4
+    for version in python_versions:
+        if version[0] == 2:
+            # The minimum protocol version for the versions of Python that we
+            # support (2.7 and 3.3+) is 2.
+            return 2
+        if version[1] < 4:
+            protocol = 3
+    return protocol
 
 
 try:

--- a/jedi/api/environment.py
+++ b/jedi/api/environment.py
@@ -98,7 +98,7 @@ class Environment(_BaseEnvironment):
         return EvaluatorSubprocess(evaluator, self._get_subprocess())
 
     def _get_subprocess(self):
-        return get_subprocess(self.executable)
+        return get_subprocess(self.executable, self.version_info)
 
     @memoize_method
     def get_sys_path(self):

--- a/jedi/evaluate/compiled/subprocess/__init__.py
+++ b/jedi/evaluate/compiled/subprocess/__init__.py
@@ -17,7 +17,7 @@ import traceback
 from functools import partial
 
 from jedi._compatibility import queue, is_py3, force_unicode, \
-    pickle_dump, pickle_load, GeneralizedPopen
+    pickle_dump, pickle_load, highest_pickle_protocol, GeneralizedPopen
 from jedi.cache import memoize_method
 from jedi.evaluate.compiled.subprocess import functions
 from jedi.evaluate.compiled.access import DirectObjectAccess, AccessPath, \
@@ -29,11 +29,12 @@ _subprocesses = {}
 _MAIN_PATH = os.path.join(os.path.dirname(__file__), '__main__.py')
 
 
-def get_subprocess(executable):
+def get_subprocess(executable, version):
     try:
         return _subprocesses[executable]
     except KeyError:
-        sub = _subprocesses[executable] = _CompiledSubprocess(executable)
+        sub = _subprocesses[executable] = _CompiledSubprocess(executable,
+                                                              version)
         return sub
 
 
@@ -125,9 +126,11 @@ class EvaluatorSubprocess(_EvaluatorProcess):
 class _CompiledSubprocess(object):
     _crashed = False
 
-    def __init__(self, executable):
+    def __init__(self, executable, version):
         self._executable = executable
         self._evaluator_deletion_queue = queue.deque()
+        self._pickle_protocol = highest_pickle_protocol([sys.version_info,
+                                                         version])
 
     @property
     @memoize_method
@@ -136,7 +139,8 @@ class _CompiledSubprocess(object):
         args = (
             self._executable,
             _MAIN_PATH,
-            os.path.dirname(os.path.dirname(parso_path))
+            os.path.dirname(os.path.dirname(parso_path)),
+            str(self._pickle_protocol)
         )
         return GeneralizedPopen(
             args,
@@ -190,7 +194,7 @@ class _CompiledSubprocess(object):
 
         data = evaluator_id, function, args, kwargs
         try:
-            pickle_dump(data, self._process.stdin)
+            pickle_dump(data, self._process.stdin, self._pickle_protocol)
         except (socket.error, IOError) as e:
             # Once Python2 will be removed we can just use `BrokenPipeError`.
             # Also, somehow in windows it returns EINVAL instead of EPIPE if
@@ -236,11 +240,12 @@ class _CompiledSubprocess(object):
 
 
 class Listener(object):
-    def __init__(self):
+    def __init__(self, pickle_protocol):
         self._evaluators = {}
         # TODO refactor so we don't need to process anymore just handle
         # controlling.
         self._process = _EvaluatorProcess(Listener)
+        self._pickle_protocol = pickle_protocol
 
     def _get_evaluator(self, function, evaluator_id):
         from jedi.evaluate import Evaluator
@@ -307,7 +312,7 @@ class Listener(object):
             except Exception as e:
                 result = True, traceback.format_exc(), e
 
-            pickle_dump(result, file=stdout)
+            pickle_dump(result, stdout, self._pickle_protocol)
 
 
 class AccessHandle(object):

--- a/jedi/evaluate/compiled/subprocess/__main__.py
+++ b/jedi/evaluate/compiled/subprocess/__main__.py
@@ -45,5 +45,7 @@ else:
     load('jedi')
     from jedi.evaluate.compiled import subprocess  # NOQA
 
+# Retrieve the pickle protocol.
+pickle_protocol = int(sys.argv[2])
 # And finally start the client.
-subprocess.Listener().listen()
+subprocess.Listener(pickle_protocol).listen()

--- a/test/test_compatibility.py
+++ b/test/test_compatibility.py
@@ -1,0 +1,26 @@
+from collections import namedtuple
+from jedi._compatibility import highest_pickle_protocol
+
+
+def test_highest_pickle_protocol():
+    v = namedtuple('version', 'major, minor')
+    assert highest_pickle_protocol([v(2, 7), v(2, 7)]) == 2
+    assert highest_pickle_protocol([v(2, 7), v(3, 3)]) == 2
+    assert highest_pickle_protocol([v(2, 7), v(3, 4)]) == 2
+    assert highest_pickle_protocol([v(2, 7), v(3, 5)]) == 2
+    assert highest_pickle_protocol([v(2, 7), v(3, 6)]) == 2
+    assert highest_pickle_protocol([v(3, 3), v(2, 7)]) == 2
+    assert highest_pickle_protocol([v(3, 3), v(3, 3)]) == 3
+    assert highest_pickle_protocol([v(3, 3), v(3, 4)]) == 3
+    assert highest_pickle_protocol([v(3, 3), v(3, 5)]) == 3
+    assert highest_pickle_protocol([v(3, 3), v(3, 6)]) == 3
+    assert highest_pickle_protocol([v(3, 4), v(2, 7)]) == 2
+    assert highest_pickle_protocol([v(3, 4), v(3, 3)]) == 3
+    assert highest_pickle_protocol([v(3, 4), v(3, 4)]) == 4
+    assert highest_pickle_protocol([v(3, 4), v(3, 5)]) == 4
+    assert highest_pickle_protocol([v(3, 4), v(3, 6)]) == 4
+    assert highest_pickle_protocol([v(3, 6), v(2, 7)]) == 2
+    assert highest_pickle_protocol([v(3, 6), v(3, 3)]) == 3
+    assert highest_pickle_protocol([v(3, 6), v(3, 4)]) == 4
+    assert highest_pickle_protocol([v(3, 6), v(3, 5)]) == 4
+    assert highest_pickle_protocol([v(3, 6), v(3, 6)]) == 4


### PR DESCRIPTION
Currently, Jedi uses version 2 of the pickle protocol to be compatible with all supported versions of Python. However, we can be smarter and use the highest version of the pickle protocol that is compatible with the version of Python running Jedi itself and the one running the environment. Examples:
 - if both Jedi and the environment are running under Python 3.6, use version 4 of the protocol;
 - if Jedi is running under Python 3.6 but the environment is Python 3.3, use version 3;
 - if Jedi is running under Python 3.6 but the environment is Python 2.7, use version 2;
 - etc.

The reason for using the highest possible version of the pickle protocol is that performance is better with newer versions of the protocol as shown by the following results:

<table>
  <tr>    
    <th>Interpreter</th>
    <th colspan="4">Python 2.7</th>
    <th colspan="4">Python 3.6</th>
  </tr>
  <tr>    
    <th>Environment</th>
    <th colspan="2">Python 2.7</th>
    <th colspan="2">Python 3.6</th>
    <th colspan="2">Python 2.7</th>
    <th colspan="2">Python 3.6</th>
  </tr>
  <tr>
    <th rowspan="2">Pickle protocol</th>    
    <td>Before</td>
    <td>After</td>
    <td>Before</td>
    <td>After</td>
    <td>Before</td>
    <td>After</td>
    <td>Before</td>
    <td>After</td>
  </tr>
  <tr>    
    <td>2</td>
    <td>2</td>
    <td>2</td>
    <td>2</td>
    <td>2</td>
    <td>2</td>
    <td>2</td>
    <td>4</td>
  </tr>
  <tr>    
    <th>os</th>
    <td>0.153s</td>
    <td>0.159s</td>
    <td>0.185s</td>
    <td>0.184s</td>
    <td>0.0978s</td>
    <td>0.105s</td>
    <td>0.074s</td>
    <td>0.0714s</td>
  </tr>
  <tr>
    <th>numpy</th>
    <td>0.271s</td>
    <td>0.26s</td>
    <td>0.262s</td>
    <td>0.259s</td>
    <td>0.206s</td>
    <td>0.198s</td>
    <td>0.188s</td>
    <td>0.173s</td>
  </tr>
  <tr> 
    <th>cv2</th>
    <td>0.964s</td>
    <td>0.949s</td>
    <td>1.08s</td>
    <td>1.07s</td>
    <td>0.513s</td>
    <td>0.513s</td>
    <td>0.465s</td>
    <td>0.308s</td>
  </tr>  
</table>

*Measurements obtained with [this script](https://gist.github.com/micbou/28eae3625de4820dac04b3b38ee0789b) when completing the `os`, `numpy`, and `cv2` ([opencv-python](https://pypi.org/project/opencv-python/)) modules on Ubuntu 18.04 64-bit.*

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/davidhalter/jedi/1152)
<!-- Reviewable:end -->
