### PR TITLE
Force unicode when listing module names

### DIFF
--- a/jedi/evaluate/compiled/subprocess/functions.py
+++ b/jedi/evaluate/compiled/subprocess/functions.py
@@ -69,7 +69,7 @@ def get_module_info(evaluator, sys_path=None, full_name=None, **kwargs):
 
 def list_module_names(evaluator, search_path):
     return [
-        name
+        force_unicode(name)
         for module_loader, name, is_pkg in iter_modules(search_path)
     ]
 


### PR DESCRIPTION
`pkgutil.iter_modules` return the module name as `str` instead of `unicode` for egg packages on Python 2. This causes the following exception if Jedi is running on Python 3 and the environment is Python 2:
```python
Traceback (most recent call last):
  File "script.py", line 36, in <module>
    jedi.Script('from ', environment=environment).completions()
  File "jedi\api\__init__.py", line 174, in completions
    completions = completion.completions()
  File "jedi\api\completion.py", line 103, in completions
    return sorted(completions, key=lambda x: (x.name.startswith('__'),
  File "jedi\api\completion.py", line 36, in filter_names
    if string.startswith(like_name):
TypeError: startswith first arg must be bytes or a tuple of bytes, not str
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/davidhalter/jedi/1156)
<!-- Reviewable:end -->
