### PR TITLE
WIP: improve docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,7 +13,6 @@
 
 import sys
 import os
-import datetime
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -274,7 +273,8 @@ autodoc_default_flags = []
 # -- Options for intersphinx module --------------------------------------------
 
 intersphinx_mapping = {
-    'https://docs.python.org/': None,
+    'python': ('https://docs.python.org/', None),
+    'parso': ('https://parso.readthedocs.io/en/latest/', None),
 }
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -145,7 +145,7 @@ html_sidebars = {
         #'relations.html',
         'ghbuttons.html',
         #'sourcelink.html',
-        #'searchbox.html'
+        'searchbox.html'
     ]
 }
 

--- a/docs/docs/development.rst
+++ b/docs/docs/development.rst
@@ -57,11 +57,11 @@ because that's where all the magic happens. I need to introduce the :ref:`parser
 Parser
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Jedi used to have it's internal parser, however this is now a separate project
+Jedi used to have its internal parser, however this is now a separate project
 and is called `parso <http://parso.readthedocs.io>`_.
 
 The parser creates a syntax tree that |jedi| analyses and tries to understand.
-The grammar that this parsers uses is very similar to the official Python
+The grammar that this parser uses is very similar to the official Python
 `grammar files <https://docs.python.org/3/reference/grammar.html>`_.
 
 .. _evaluate:

--- a/jedi/api/__init__.py
+++ b/jedi/api/__init__.py
@@ -55,10 +55,8 @@ class Script(object):
     - if `sys_path` parameter is not ``None``, it will be used as ``sys.path``
       for the script;
 
-    - if `sys_path` parameter is ``None`` and ``VIRTUAL_ENV`` environment
-      variable is defined, ``sys.path`` for the specified environment will be
-      guessed (see :func:`jedi.evaluate.sys_path.get_venv_path`) and used for
-      the script;
+    - if `environment` is provided, its ``sys.path`` will be used
+      (see :func:`Environment.get_sys_path <jedi.api.environment.Environment.get_sys_path>`);
 
     - otherwise ``sys.path`` will match that of |jedi|.
 
@@ -160,11 +158,13 @@ class Script(object):
 
     def completions(self):
         """
-        Return :class:`classes.Completion` objects. Those objects contain
-        information about the completions, more than just names.
+        Return :class:`.Completion` objects.
+
+        Those objects contain information about the completions, more than just
+        names.
 
         :return: Completion objects, sorted by name and __ comes last.
-        :rtype: list of :class:`classes.Completion`
+        :rtype: list of :class:`.Completion`
         """
         debug.speed('completions start')
         completion = Completion(
@@ -185,7 +185,7 @@ class Script(object):
         because Python itself is a dynamic language, which means depending on
         an option you can have two different versions of a function.
 
-        :rtype: list of :class:`classes.Definition`
+        :rtype: list of :class:`.Definition`
         """
         leaf = self._module_node.get_name_of_position(self._pos)
         if leaf is None:
@@ -210,7 +210,7 @@ class Script(object):
         dynamic language, which means depending on an option you can have two
         different versions of a function.
 
-        :rtype: list of :class:`classes.Definition`
+        :rtype: list of :class:`.Definition`
         """
         def filter_follow_imports(names, check):
             for name in names:
@@ -240,14 +240,14 @@ class Script(object):
 
     def usages(self, additional_module_paths=()):
         """
-        Return :class:`classes.Definition` objects, which contain all
+        Return :class:`.Definition` objects, which contain all
         names that point to the definition of the name under the cursor. This
         is very useful for refactoring (renaming), or to show all usages of a
         variable.
 
         .. todo:: Implement additional_module_paths
 
-        :rtype: list of :class:`classes.Definition`
+        :rtype: list of :class:`.Definition`
         """
         tree_name = self._module_node.get_name_of_position(self._pos)
         if tree_name is None:
@@ -273,7 +273,7 @@ class Script(object):
 
         This would return an empty list..
 
-        :rtype: list of :class:`classes.CallSignature`
+        :rtype: list of :class:`.CallSignature`
         """
         call_signature_details = \
             helpers.get_call_signature_details(self._module_node, self._pos)

--- a/jedi/api/classes.py
+++ b/jedi/api/classes.py
@@ -311,8 +311,9 @@ class BaseDefinition(object):
     @memoize_method
     def params(self):
         """
-        Raises an ``AttributeError``if the definition is not callable.
-        Otherwise returns a list of `Definition` that represents the params.
+        Raises :exc:`AttributeError` if the definition is not callable.
+        Otherwise returns a list of :class:`.Definition` that represents the
+        params.
         """
         def get_param_names(context):
             param_names = []

--- a/jedi/api/environment.py
+++ b/jedi/api/environment.py
@@ -64,8 +64,8 @@ class Environment(_BaseEnvironment):
         self.version_info = self._get_version()
         """
 
-        Like ``sys.version_info``. A tuple to show the current Environment's
-        Python version.
+        Like :data:`sys.version_info`: a tuple to show the current
+        Environment's Python version.
         """
 
     def _get_version(self):
@@ -104,7 +104,7 @@ class Environment(_BaseEnvironment):
     def get_sys_path(self):
         """
         The sys path for this environment. Does not include potential
-        modifications like ``sys.path.append``.
+        modifications from e.g. appending to :data:`sys.path`.
 
         :returns: list of str
         """
@@ -162,7 +162,7 @@ def get_default_environment():
     makes it possible to use as many new Python features as possible when using
     autocompletion and other functionality.
 
-    :returns: :class:`Environment`
+    :returns: :class:`.Environment`
     """
     virtual_env = _get_virtual_env_from_var()
     if virtual_env is not None:
@@ -193,7 +193,7 @@ def find_virtualenvs(paths=None, **kwargs):
         default. If the executable has not been installed by root, it will not
         be executed.
 
-    :yields: :class:`Environment`
+    :yields: :class:`.Environment`
     """
     def py27_comp(paths=None, safe=True):
         if paths is None:
@@ -237,7 +237,7 @@ def find_system_environments():
 
     The environments are sorted from latest to oldest Python version.
 
-    :yields: :class:`Environment`
+    :yields: :class:`.Environment`
     """
     for version_string in _SUPPORTED_PYTHONS:
         try:
@@ -271,7 +271,7 @@ def get_system_environment(version):
     where X and Y are the major and minor versions of Python.
 
     :raises: :exc:`.InvalidPythonEnvironment`
-    :returns: :class:`Environment`
+    :returns: :class:`.Environment`
     """
     exe = which('python' + version)
     if exe:

--- a/jedi/evaluate/compiled/context.py
+++ b/jedi/evaluate/compiled/context.py
@@ -18,7 +18,7 @@ from . import fake
 
 
 class CheckAttribute(object):
-    """Raises an AttributeError if the attribute X isn't available."""
+    """Raises :exc:`AttributeError` if the attribute X is not available."""
     def __init__(self, func):
         self.func = func
         # Remove the py in front of e.g. py__call__.

--- a/jedi/evaluate/context/module.py
+++ b/jedi/evaluate/context/module.py
@@ -171,7 +171,7 @@ class ModuleContext(TreeContext):
 
         In case of a package, this returns Python's __path__ attribute, which
         is a list of paths (strings).
-        Raises an AttributeError if the module is not a package.
+        Raises :exc:`AttributeError` if the module is not a package.
         """
         path = self._get_init_directory()
 

--- a/jedi/evaluate/recursion.py
+++ b/jedi/evaluate/recursion.py
@@ -3,8 +3,8 @@ Recursions are the recipe of |jedi| to conquer Python code. However, someone
 must stop recursions going mad. Some settings are here to make |jedi| stop at
 the right time. You can read more about them :ref:`here <settings-recursion>`.
 
-Next to :mod:`jedi.evaluate.cache` this module also makes |jedi| not
-thread-safe. Why?  ``execution_recursion_decorator`` uses class variables to
+Next to the internal ``jedi.evaluate.cache`` this module also makes |jedi| not
+thread-safe, because ``execution_recursion_decorator`` uses class variables to
 count the function calls.
 
 .. _settings-recursion:
@@ -34,7 +34,7 @@ from jedi.evaluate.base_context import NO_CONTEXTS
 
 recursion_limit = 15
 """
-Like ``sys.getrecursionlimit()``, just for |jedi|.
+Like :func:`sys.getrecursionlimit()`, just for |jedi|.
 """
 total_function_execution_limit = 200
 """


### PR DESCRIPTION
TODO:

- [ ] fix all warnings reported by `sphinx-build -n` (~20 left)
- [ ] add tox env to build docs, use picky mode on Travis there then.  Could have just two envs, or pass `-n` on Travis then.  `-W` is already used to exit non-zero on warnings, but currently Sphinx displays the first warning then only (https://github.com/sphinx-doc/sphinx/issues/4614)