### PR TITLE
subprocess: listen: exit normally with EOFError

### DIFF
--- a/jedi/evaluate/compiled/subprocess/__init__.py
+++ b/jedi/evaluate/compiled/subprocess/__init__.py
@@ -304,9 +304,9 @@ class Listener(object):
             try:
                 payload = pickle_load(stdin)
             except EOFError:
-                # It looks like the parent process closed. Don't make a big fuss
-                # here and just exit.
-                exit(1)
+                # It looks like the parent process closed.
+                # Don't make a big fuss here and just exit.
+                exit(0)
             try:
                 result = False, None, self._run(*payload)
             except Exception as e:


### PR DESCRIPTION
This is an expected case, since the parent closed normally, and
therefore the subprocess should exit with 0.