### PR TITLE
Add params to CallSignature.__repr__

### DIFF
--- a/jedi/api/classes.py
+++ b/jedi/api/classes.py
@@ -638,9 +638,18 @@ class CallSignature(Definition):
         """
         return self._bracket_start_pos
 
+    @property
+    def _params_str(self):
+        return ', '.join([p.description[6:]
+                          for p in self.params])
+
     def __repr__(self):
-        return '<%s: %s index %s>' % \
-            (type(self).__name__, self._name.string_name, self.index)
+        return '<%s: %s index=%r params=[%s]>' % (
+            type(self).__name__,
+            self._name.string_name,
+            self._index,
+            self._params_str,
+        )
 
 
 class _Help(object):


### PR DESCRIPTION
Looks like this for `jedi.Script` then:

> <CallSignature: Script index=0 params=[source=None, line=None, column=None, path=None, encoding='utf-8', sys_path=None, environment=None]>

`_params_str` could be made public, and then could be used in jedi-vim,
which currently has this:

    params = [p.description.replace('\n', '').replace('param ', '', 1)
              for p in signature.params]

https://github.com/davidhalter/jedi-vim/blob/08792d3fd742ec9d8cb75fe1e2a799244ee45fe3/pythonx/jedi_vim.py#L492-L493