### PR TITLE
[RFC] Add qa env

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,3 +6,4 @@ max-line-length = 100
 ignore =
   # do not use bare 'except'
   E722,
+exclude = test/*

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,9 @@ setup(name='jedi',
               # coloroma for colored debug output
               'colorama',
           ],
+          'qa': [
+              'flake8==3.5.0',
+          ],
       },
       package_data={'jedi': ['evaluate/compiled/fake/*.pym']},
       platforms=['any'],

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py34, py35, py36
+envlist = py27, py34, py35, py36, qa
 [testenv]
 extras = testing
 # Overwrite the parso version (only used sometimes).
@@ -46,3 +46,7 @@ commands =
 commands =
     {envpython} -c "import os; a='{envtmpdir}'; os.path.exists(a) or os.makedirs(a)"
     {envpython} sith.py --record {envtmpdir}/record.json random {posargs:jedi}
+[testenv:qa]
+commands = flake8 {posargs:jedi}
+deps =
+extras = qa


### PR DESCRIPTION
Ignores tests with flake8 completely for now.

Many failures, so should not really get enabled yet, but might be a good base for local checking.