### PR TITLE
_get_virtual_env_from_var: use safe=False

### DIFF
--- a/jedi/api/environment.py
+++ b/jedi/api/environment.py
@@ -147,13 +147,18 @@ class InterpreterEnvironment(_BaseEnvironment):
 
 
 def _get_virtual_env_from_var():
+    """Get virtualenv environment from VIRTUAL_ENV environment variable.
+
+    It uses `safe=False` with ``create_environment``, because the environment
+    variable is considered to be safe / controlled by the user solely.
+    """
     var = os.environ.get('VIRTUAL_ENV')
     if var is not None:
         if var == sys.prefix:
             return SameEnvironment()
 
         try:
-            return create_environment(var)
+            return create_environment(var, safe=False)
         except InvalidPythonEnvironment:
             pass
 

--- a/test/test_api/test_environment.py
+++ b/test/test_api/test_environment.py
@@ -110,3 +110,22 @@ def test_create_environment_venv_path(venv_path):
 def test_create_environment_executable():
     environment = create_environment(sys.executable)
     assert environment.executable == sys.executable
+
+
+def test_get_default_environment_from_env_does_not_use_safe(tmpdir, monkeypatch):
+    fake_python = os.path.join(str(tmpdir), 'fake_python')
+    with open(fake_python, 'w') as f:
+        f.write('')
+
+    def _get_subprocess(self):
+        if self._start_executable != fake_python:
+            raise RuntimeError('Should not get called!')
+        self.executable = fake_python
+        self.path = 'fake'
+
+    monkeypatch.setattr('jedi.api.environment.Environment._get_subprocess',
+                        _get_subprocess)
+
+    monkeypatch.setenv('VIRTUAL_ENV', fake_python)
+    env = get_default_environment()
+    assert env.path == 'fake'


### PR DESCRIPTION
Without this creating an env from VIRTUAL_ENV will always silently fail
if it is not the same/current environment.

TODO:

- [ ] I think it would be good to have some logging in case it would still fail for other reasons, but there is no `logger` yet.