### PR TITLE
jedi.api.environment._SUPPORTED_PYTHONS: add 3.7

### DIFF
--- a/jedi/api/environment.py
+++ b/jedi/api/environment.py
@@ -17,7 +17,7 @@ import parso
 
 _VersionInfo = namedtuple('VersionInfo', 'major minor micro')
 
-_SUPPORTED_PYTHONS = ['3.6', '3.5', '3.4', '3.3', '2.7']
+_SUPPORTED_PYTHONS = ['3.7', '3.6', '3.5', '3.4', '3.3', '2.7']
 _SAFE_PATHS = ['/usr/bin', '/usr/local/bin']
 _CURRENT_VERSION = '%s.%s' % (sys.version_info.major, sys.version_info.minor)
 


### PR DESCRIPTION
The grammar is available in parso already, and it works in general.