### PR TITLE
Fix for PEP448-style dict unpacking

### DIFF
--- a/jedi/evaluate/context/iterable.py
+++ b/jedi/evaluate/context/iterable.py
@@ -351,13 +351,19 @@ class SequenceLiteralContext(Sequence):
             kv = []
             iterator = iter(array_node.children)
             for key in iterator:
-                op = next(iterator, None)
-                if op is None or op == ',':
-                    kv.append(key)  # A set.
-                else:
-                    assert op == ':'  # A dict.
-                    kv.append((key, next(iterator)))
+                if key == "**":
+                    # dict with pep 448 double-star unpacking
+                    # for now ignoring the values imported by **
+                    next(iterator)
                     next(iterator, None)  # Possible comma.
+                else:
+                    op = next(iterator, None)
+                    if op is None or op == ',':
+                        kv.append(key)  # A set.
+                    else:
+                        assert op == ':'  # A dict.
+                        kv.append((key, next(iterator)))
+                        next(iterator, None)  # Possible comma.
             return kv
         else:
             return [array_node]

--- a/jedi/evaluate/context/iterable.py
+++ b/jedi/evaluate/context/iterable.py
@@ -346,7 +346,9 @@ class SequenceLiteralContext(Sequence):
             return []  # Direct closing bracket, doesn't contain items.
 
         if array_node.type == 'testlist_comp':
-            return array_node.children[::2]
+            # filter out (for now) pep 448 single-star unpacking
+            return [value for value in array_node.children[::2]
+                    if value.type != "star_expr"]
         elif array_node.type == 'dictorsetmaker':
             kv = []
             iterator = iter(array_node.children)
@@ -359,14 +361,24 @@ class SequenceLiteralContext(Sequence):
                 else:
                     op = next(iterator, None)
                     if op is None or op == ',':
-                        kv.append(key)  # A set.
+                        if key.type == "star_expr":
+                            # pep 448 single-star unpacking
+                            # for now ignoring values imported by *
+                            pass
+                        else:
+                            kv.append(key)  # A set.
                     else:
                         assert op == ':'  # A dict.
                         kv.append((key, next(iterator)))
                         next(iterator, None)  # Possible comma.
             return kv
         else:
-            return [array_node]
+            if array_node.type == "star_expr":
+                # pep 448 single-star unpacking
+                # for now ignoring values imported by *
+                return []
+            else:
+                return [array_node]
 
     def exact_key_items(self):
         """

--- a/jedi/evaluate/syntax_tree.py
+++ b/jedi/evaluate/syntax_tree.py
@@ -255,7 +255,8 @@ def eval_atom(context, atom):
             array_node_c = array_node.children
         except AttributeError:
             array_node_c = []
-        if c[0] == '{' and (array_node == '}' or ':' in array_node_c):
+        if c[0] == '{' and (array_node == '}' or ':' in array_node_c or
+                            '**' in array_node_c):
             context = iterable.DictLiteralContext(context.evaluator, context, atom)
         else:
             context = iterable.SequenceLiteralContext(context.evaluator, context, atom)

--- a/test/completion/types.py
+++ b/test/completion/types.py
@@ -137,5 +137,15 @@ set_t2.c
 # -----------------
 # python >= 3.5
 
+d = {'a': 3}
+
 #? dict()
 {**d}
+
+#? str()
+{**d, "b": "b"}["b"]
+
+# Should resolve to int() but jedi is not smart enough yet
+# Here to make sure it doesn't result in crash though
+#? str()
+{**d, "b": "b"}["a"]

--- a/test/completion/types.py
+++ b/test/completion/types.py
@@ -147,5 +147,30 @@ d = {'a': 3}
 
 # Should resolve to int() but jedi is not smart enough yet
 # Here to make sure it doesn't result in crash though
-#? str()
-{**d, "b": "b"}["a"]
+#? 
+{**d}["a"]
+
+s = {1, 2, 3}
+
+#? set()
+{*s}
+
+#? set()
+{*s, 4, *s}
+
+s = {1, 2, 3}
+# Should resolve to int() but jedi is not smart enough yet
+# Here to make sure it doesn't result in crash though
+#? 
+{*s}.pop()
+
+#? int()
+{*s, 4}.pop()
+
+# Should resolve to int() but jedi is not smart enough yet
+# Here to make sure it doesn't result in crash though
+#? 
+[*s][0]
+
+#? int()
+[*s, 4][0]

--- a/test/completion/types.py
+++ b/test/completion/types.py
@@ -131,3 +131,11 @@ set_t2 = set()
 
 #? ['clear', 'copy']
 set_t2.c
+
+# -----------------
+# pep 448 unpacking generalizations
+# -----------------
+# python >= 3.5
+
+#? dict()
+{**d}


### PR DESCRIPTION
Fixes #1222 by not crashing anymore.

For now it just ignores the `**d` part

```
d = {'a': 3}

#? dict()
{**d}

#? str()
{**d, "b": "b"}["b"]

# Should resolve to int() but jedi is not smart enough yet
# Here to make sure it doesn't result in crash though
#? 
{**d}["a"]
```