### PR TITLE
Add an exact_key_items method to DictComprehension

### DIFF
--- a/jedi/evaluate/context/iterable.py
+++ b/jedi/evaluate/context/iterable.py
@@ -267,6 +267,11 @@ class DictComprehension(ComprehensionMixin, Sequence):
 
         return ContextSet(FakeSequence(self.evaluator, u'list', lazy_contexts))
 
+    def exact_key_items(self):
+        # NOTE: A smarter thing can probably done here to achieve better
+        # completions, but at least like this jedi doesn't crash
+        return []
+
 
 class GeneratorComprehension(ComprehensionMixin, GeneratorBase):
     pass

--- a/test/completion/functions.py
+++ b/test/completion/functions.py
@@ -319,12 +319,26 @@ exe['c']
 a = 'a'
 exe2 = kwargs_func(**{a:3,
                       'b':4.0})
+
 #? int()
 exe2['a']
 #? float()
 exe2['b']
 #? int() float()
 exe2['c']
+
+exe3 = kwargs_func(**{k: v for k, v in [(a, 3), ('b', 4.0)]})
+
+# Should resolve to the same as 2 but jedi is not smart enough yet
+# Here to make sure it doesn't result in crash though
+#? 
+exe3['a']
+
+#? 
+exe3['b']
+
+#? 
+exe3['c']
 
 # -----------------
 # *args / ** kwargs

--- a/test/completion/types.py
+++ b/test/completion/types.py
@@ -138,17 +138,29 @@ set_t2.c
 # python >= 3.5
 
 d = {'a': 3}
+dc = {v: 3 for v in ['a']}
 
 #? dict()
 {**d}
 
+#? dict()
+{**dc}
+
 #? str()
 {**d, "b": "b"}["b"]
+
+#? str()
+{**dc, "b": "b"}["b"]
 
 # Should resolve to int() but jedi is not smart enough yet
 # Here to make sure it doesn't result in crash though
 #? 
 {**d}["a"]
+
+# Should resolve to int() but jedi is not smart enough yet
+# Here to make sure it doesn't result in crash though
+#? 
+{**dc}["a"]
 
 s = {1, 2, 3}
 


### PR DESCRIPTION
This fixes #1233, which made jedi unusable for me because it kept crashing.