### PR TITLE
Fix environment cache regression

### DIFF
--- a/jedi/api/environment.py
+++ b/jedi/api/environment.py
@@ -190,8 +190,9 @@ def get_default_environment():
 
 
 def get_cached_default_environment():
+    var = os.environ.get('VIRTUAL_ENV')
     environment = _get_cached_default_environment()
-    if environment.path != os.environ.get('VIRTUAL_ENV'):
+    if var and var != environment.path:
         _get_cached_default_environment.clear_cache()
         return _get_cached_default_environment()
     return environment


### PR DESCRIPTION
Currently, if `VIRTUAL_ENV` is empty, which will occur when we don't use a virtual environment, the `get_cached_default_environment` will always clear the cache. 
I think it's a regression caused by 862f61182941a451c8e158091a328d63cb4ef43b.