### PR TITLE
Improve docstring formatting

### DIFF
--- a/jedi/parser_utils.py
+++ b/jedi/parser_utils.py
@@ -1,3 +1,4 @@
+import re
 import textwrap
 from inspect import cleandoc
 
@@ -158,6 +159,7 @@ def get_call_signature(funcdef, width=72, call_string=None):
         p = '(' + ''.join(param.get_code() for param in funcdef.get_params()).strip() + ')'
     else:
         p = funcdef.children[2].get_code()
+    p = re.sub(r'\s+', ' ', p)
     if funcdef.annotation:
         rtype = " ->" + funcdef.annotation.get_code()
     else:
@@ -183,6 +185,8 @@ def get_doc_with_call_signature(scope_node):
     doc = clean_scope_docstring(scope_node)
     if call_signature is None:
         return doc
+    if not doc:
+        return call_signature
     return '%s\n\n%s' % (call_signature, doc)
 
 

--- a/test/test_evaluate/test_docstring.py
+++ b/test/test_evaluate/test_docstring.py
@@ -142,6 +142,16 @@ def test_docstring_keyword(Script):
     assert 'assert' in completions[0].docstring()
 
 
+def test_docstring_params_formatting(Script):
+    defs = Script("""
+    def func(param1,
+             param2,
+             param3):
+        pass
+    func""").goto_definitions()
+    assert defs[0].docstring() == 'func(param1, param2, param3)'
+
+
 # ---- Numpy Style Tests ---
 
 @pytest.mark.skipif(numpydoc_unavailable,

--- a/test/test_parso_integration/test_parser_utils.py
+++ b/test/test_parso_integration/test_parser_utils.py
@@ -85,4 +85,4 @@ def test_get_call_signature(code, call_signature):
         node = node.children[0]
     assert parser_utils.get_call_signature(node) == call_signature
 
-    assert parser_utils.get_doc_with_call_signature(node) == (call_signature + '\n\n')
+    assert parser_utils.get_doc_with_call_signature(node) == call_signature


### PR DESCRIPTION
A common practice when a function has a lot of parameters is to write one parameter on each line, e.g.
```python
def func(param1,
         param2,        
         param3):
  pass
```
Jedi returns the following signature as part of the docstring for that function:
```
func(param1,          param2,          param3)\n\n
```
which is not ideal. With this PR, Jedi returns
```
func(param1, param2, param3)
```
instead.