### PR TITLE
Add fuzzy completion.

### DIFF
--- a/jedi/api/completion.py
+++ b/jedi/api/completion.py
@@ -1,3 +1,5 @@
+import re
+
 from parso.python.token import PythonTokenTypes
 from parso.python import tree
 from parso.tree import search_ancestor, Leaf
@@ -33,7 +35,13 @@ def filter_names(evaluator, completion_names, stack, like_name):
         if settings.case_insensitive_completion:
             string = string.lower()
 
-        if string.startswith(like_name):
+        if settings.fuzzy_completion:
+            pattern = '.*'.join(like_name) + '.*'
+            match = re.match(pattern, string)
+        else:
+            match = string.startswith(like_name)
+
+        if match:
             new = classes.Completion(
                 evaluator,
                 name,

--- a/jedi/settings.py
+++ b/jedi/settings.py
@@ -16,6 +16,7 @@ Completion output
 ~~~~~~~~~~~~~~~~~
 
 .. autodata:: case_insensitive_completion
+.. autodata:: fuzzy_completion
 .. autodata:: add_bracket_after_function
 .. autodata:: no_completion_duplicates
 
@@ -60,6 +61,11 @@ import platform
 case_insensitive_completion = True
 """
 The completion is by default case insensitive.
+"""
+
+fuzzy_completion = False
+"""
+The completion is non-fuzzy by default.
 """
 
 add_bracket_after_function = False

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(name='jedi',
       install_requires=install_requires,
       extras_require={
           'testing': [
-              'pytest>=2.3.5',
+              'pytest<4.0.0',
               # docopt for sith doctests
               'docopt',
               # coloroma for colored debug output


### PR DESCRIPTION
I've added a simple fuzzy completion. It can be enabled by setting `settings.fuzzy_completion` to True.

I enable it in `jedi-vim` as follows (tell me if there's a better way, I couldn't find one):

```vimscript
" .vimrc
au FileType python :py3 from jedi import settings; settings.fuzzy_completion = 1
```

This code can be improved even more by using Levenshtein string distance - I've used it before and it was really very accurate and unobtrusive. As for now, I've decided to keep it minimalistic & clean.

This PR implements https://github.com/davidhalter/jedi-vim/issues/72