### PR TITLE
Use `pytest.param` when marking single parameters

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(name='jedi',
       install_requires=install_requires,
       extras_require={
           'testing': [
-              'pytest>=2.3.5',
+              'pytest>=3.1.0',
               # docopt for sith doctests
               'docopt',
               # coloroma for colored debug output

--- a/test/test_evaluate/test_imports.py
+++ b/test/test_evaluate/test_imports.py
@@ -87,10 +87,10 @@ def test_import_not_in_sys_path(Script):
     ("from flask.ext.", "bar"),
     ("from flask.ext.", "baz"),
     ("from flask.ext.", "moo"),
-    pytest.mark.xfail(("import flask.ext.foo; flask.ext.foo.", "Foo")),
-    pytest.mark.xfail(("import flask.ext.bar; flask.ext.bar.", "Foo")),
-    pytest.mark.xfail(("import flask.ext.baz; flask.ext.baz.", "Foo")),
-    pytest.mark.xfail(("import flask.ext.moo; flask.ext.moo.", "Foo")),
+    pytest.param("import flask.ext.foo; flask.ext.foo.", "Foo", marks=pytest.mark.xfail),
+    pytest.param("import flask.ext.bar; flask.ext.bar.", "Foo", marks=pytest.mark.xfail),
+    pytest.param("import flask.ext.baz; flask.ext.baz.", "Foo", marks=pytest.mark.xfail),
+    pytest.param("import flask.ext.moo; flask.ext.moo.", "Foo", marks=pytest.mark.xfail),
 ])
 def test_flask_ext(Script, code, name):
     """flask.ext.foo is really imported from flaskext.foo or flask_foo.


### PR DESCRIPTION
Marking single parameters in [`pytest.mark.parametrize`](https://docs.pytest.org/en/latest/deprecations.html#marks-in-pytest-mark-parametrize) was deprecated in 3.2 and is removed in the recent 4.0 release, which makes the collection of `test_evaluate/test_imports.py::test_flask_ext` fail. This PR makes the parameters compliant with `pytest>=4`.

Also, since the `pytest.param` feature was introduced in 3.1.0, the `pytest` dependency need to be bumped.