### PR TITLE
Expand user directory when creating environments

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -51,5 +51,6 @@ Maksim Novikov (@m-novikov) <mnovikov.work@gmail.com>
 Tobias Rzepka (@TobiasRzepka)
 micbou (@micbou)
 Dima Gerasimov (@karlicoss) <karlicoss@gmail.com>
+Ross Lannen (@rosslannen) <ross.lannen@gmail.com>
 
 Note: (@user) means a github user name.

--- a/jedi/api/environment.py
+++ b/jedi/api/environment.py
@@ -231,6 +231,7 @@ def find_virtualenvs(paths=None, **kwargs):
             _used_paths.add(virtual_env.path)
 
         for directory in paths:
+            directory = os.path.expanduser(directory)
             if not os.path.isdir(directory):
                 continue
 
@@ -298,6 +299,7 @@ def create_environment(path, safe=True):
     :raises: :exc:`.InvalidPythonEnvironment`
     :returns: :class:`Environment`
     """
+    path = os.path.expanduser(path)
     if os.path.isfile(path):
         _assert_safe(path, safe)
         return Environment(path)


### PR DESCRIPTION
Adds support for creating environments with a path beginning with `~`. Supplying paths with a `~` is default for emacs when using `pythonic-activate` from https://github.com/proofit404/pythonic.