### PR TITLE
fix get_system_environment misses if same python version has multiple installs

### DIFF
--- a/jedi/api/environment.py
+++ b/jedi/api/environment.py
@@ -286,7 +286,10 @@ def get_system_environment(version):
 
     if os.name == 'nt':
         for exe in _get_executables_from_windows_registry(version):
-            return Environment(exe)
+            try:
+                return Environment(exe)
+            except InvalidPythonEnvironment:
+                pass
     raise InvalidPythonEnvironment("Cannot find executable python%s." % version)
 
 


### PR DESCRIPTION
The Environment.__init__ may throw an InvalidPythonEnvironment if the call to _get_subprocess() fails. In this case other registered Python environments of the same Python version may still work and shall also be considered.