### PR TITLE
fixing permission denied errors with project.json

### DIFF
--- a/jedi/_compatibility.py
+++ b/jedi/_compatibility.py
@@ -348,6 +348,11 @@ try:
 except NameError:
     NotADirectoryError = IOError
 
+try:
+    PermissionError = PermissionError
+except NameError:
+    PermissionError = IOError
+
 
 def no_unicode_pprint(dct):
     """

--- a/jedi/api/project.py
+++ b/jedi/api/project.py
@@ -1,7 +1,7 @@
 import os
 import json
 
-from jedi._compatibility import FileNotFoundError, NotADirectoryError
+from jedi._compatibility import FileNotFoundError, NotADirectoryError, PermissionError
 from jedi.api.environment import SameEnvironment, \
     get_cached_default_environment
 from jedi.api.exceptions import WrongVersion
@@ -151,7 +151,7 @@ def _is_django_path(directory):
     try:
         with open(os.path.join(directory, 'manage.py'), 'rb') as f:
             return b"DJANGO_SETTINGS_MODULE" in f.read()
-    except (FileNotFoundError, NotADirectoryError):
+    except (FileNotFoundError, NotADirectoryError, PermissionError):
         return False
 
     return False
@@ -167,7 +167,7 @@ def get_default_project(path=None):
     for dir in traverse_parents(check, include_current=True):
         try:
             return Project.load(dir)
-        except (FileNotFoundError, NotADirectoryError):
+        except (FileNotFoundError, NotADirectoryError, PermissionError):
             pass
 
         if first_no_init_file is None:


### PR DESCRIPTION
We're running into issues with `jedi` on our cluster which uses automount: 
```
PermissionError: [Errno 13] Permission denied: /cluster/home/.jedi/project.json
```

This happens when jedi is walking up the FS tree in order to find a `project.json` file. With automount, an attempt to open or stat a file in the `/cluster/home` directory will create it, however, will not be accessible. This makes jedi unusable in such an environment. This PR fixes the issue for us.

Also besides this (exotic) automount issue it seems to make sense to behave in the same way when encountering `PermissionError` as with `FileNotFoundError` and `NotADirectoryError`, since the file is not accessible in either case.