### PR TITLE
Fix all resource warnings

### DIFF
--- a/jedi/_compatibility.py
+++ b/jedi/_compatibility.py
@@ -3,7 +3,9 @@ To ensure compatibility from Python ``2.7`` - ``3.x``, a module has been
 created. Clearly there is huge need to use conforming syntax.
 """
 from __future__ import print_function
+import atexit
 import errno
+import functools
 import sys
 import os
 import re
@@ -11,6 +13,7 @@ import pkgutil
 import warnings
 import inspect
 import subprocess
+import weakref
 try:
     import importlib
 except ImportError:
@@ -635,3 +638,49 @@ def which(cmd, mode=os.F_OK | os.X_OK, path=None):
                 if _access_check(name, mode):
                     return name
     return None
+
+
+if not is_py3:
+    # Simplified backport of Python 3 weakref.finalize:
+    # https://github.com/python/cpython/blob/ded4737989316653469763230036b04513cb62b3/Lib/weakref.py#L502-L662
+    class finalize(object):
+        """Class for finalization of weakrefable objects.
+
+        finalize(obj, func, *args, **kwargs) returns a callable finalizer
+        object which will be called when obj is garbage collected. The
+        first time the finalizer is called it evaluates func(*arg, **kwargs)
+        and returns the result. After this the finalizer is dead, and
+        calling it just returns None.
+
+        When the program exits any remaining finalizers will be run.
+        """
+
+        # Finalizer objects don't have any state of their own.
+        # This ensures that they cannot be part of a ref-cycle.
+        __slots__ = ()
+        _registry = {}
+
+        def __init__(self, obj, func, *args, **kwargs):
+            info = functools.partial(func, *args, **kwargs)
+            info.weakref = weakref.ref(obj, self)
+            self._registry[self] = info
+
+        def __call__(self):
+            """Return func(*args, **kwargs) if alive."""
+            info = self._registry.pop(self, None)
+            if info:
+                return info()
+
+        @classmethod
+        def _exitfunc(cls):
+            if not cls._registry:
+                return
+            for finalizer in list(cls._registry):
+                try:
+                    finalizer(None)
+                except Exception:
+                    sys.excepthook(*sys.exc_info())
+                assert finalizer not in cls._registry
+
+    atexit.register(finalize._exitfunc)
+    weakref.finalize = finalize

--- a/test/run.py
+++ b/test/run.py
@@ -357,9 +357,11 @@ def collect_dir_tests(base_dir, test_files, check_thirdparty=False):
             path = os.path.join(base_dir, f_name)
 
             if is_py3:
-                source = open(path, encoding='utf-8').read()
+                with open(path, encoding='utf-8') as f:
+                    source = f.read()
             else:
-                source = unicode(open(path).read(), 'UTF-8')
+                with open(path) as f:
+                    source = unicode(f.read(), 'UTF-8')
 
             for case in collect_file_tests(path, StringIO(source),
                                            lines_to_execute):

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,8 @@ setenv =
 # https://github.com/tomchristie/django-rest-framework/issues/1957
 # tox corrupts __pycache__, solution from here:
     PYTHONDONTWRITEBYTECODE=1
+# Enable all warnings.
+    PYTHONWARNINGS=always
 # To test Jedi in different versions than the same Python version, set a
 # different test environment.
     env27: JEDI_TEST_ENVIRONMENT=27


### PR DESCRIPTION
Environments currently generate resource warnings at deletion. For example, running the script
```python
import jedi
environment = jedi.get_system_environment('3.6')
```
with all warnings enabled gives that output:
```
$ python -Wa script.py
...
sys:1: ResourceWarning: unclosed file <_io.BufferedWriter name=3>
sys:1: ResourceWarning: unclosed file <_io.BufferedReader name=4>
```
While these warnings can be considered harmless, they generate noise when running tests in projects that depend on Jedi.

This PR enables all warnings in tests through the `PYTHONWARNINGS` environment variable and fix them by closing the file descriptors that are left open. [Since `__del__` is not guaranteed to be called when the interpreter exits](https://docs.python.org/3/reference/datamodel.html#object.__del__), we use `atexit` to ensure that the subprocess streams are closed in that case. We also need to wait for the thread reading `stderr` to be terminated (which necessarily happen if the subprocess is killed) before being able to close the stream.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/davidhalter/jedi/1295)
<!-- Reviewable:end -->
