### PR TITLE
Improve test_import_completion_docstring robustness

### DIFF
--- a/test/test_evaluate/test_imports.py
+++ b/test/test_evaluate/test_imports.py
@@ -132,13 +132,13 @@ def test_cache_works_with_sys_path_param(Script, tmpdir):
 def test_import_completion_docstring(Script):
     import abc
     s = Script('"""test"""\nimport ab')
-    completions = s.completions()
-    assert len(completions) == 1
-    assert completions[0].docstring(fast=False) == abc.__doc__
+    abc_completions = [c for c in s.completions() if c.name == 'abc']
+    assert len(abc_completions) == 1
+    assert abc_completions[0].docstring(fast=False) == abc.__doc__
 
     # However for performance reasons not all modules are loaded and the
     # docstring is empty in this case.
-    assert completions[0].docstring() == ''
+    assert abc_completions[0].docstring() == ''
 
 
 def test_goto_definition_on_import(Script):


### PR DESCRIPTION
The `import_completion_docstring` test fails if there are other modules than `abc` whose name starts with `ab` (e.g. [`absl`](https://github.com/abseil/abseil-py)). This is fixed by filtering out all completions with a name different than `abc`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/davidhalter/jedi/1296)
<!-- Reviewable:end -->
