### PR TITLE
fix add_bracket_after_function had no effect

### DIFF
--- a/jedi/api/classes.py
+++ b/jedi/api/classes.py
@@ -397,7 +397,7 @@ class Completion(BaseDefinition):
     def _complete(self, like_name):
         append = ''
         if settings.add_bracket_after_function \
-                and self.type == 'Function':
+                and self.type == 'function':
             append = '('
 
         if self._name.api_type == 'param' and self._stack is not None:

--- a/test/test_api/test_settings.py
+++ b/test/test_api/test_settings.py
@@ -23,8 +23,9 @@ def test_add_dynamic_mods(Script):
     assert result[0].description == 'class int'
 
 
-def test_add_bracket_after_function(Script):
-    api.settings.add_bracket_after_function = True
+def test_add_bracket_after_function(monkeypatch, Script):
+    settings = api.settings
+    monkeypatch.setattr(settings, 'add_bracket_after_function', True)
     script = Script('''\
 def foo():
     pass

--- a/test/test_api/test_settings.py
+++ b/test/test_api/test_settings.py
@@ -21,3 +21,13 @@ def test_add_dynamic_mods(Script):
     result = script.goto_definitions()
     assert len(result) == 1
     assert result[0].description == 'class int'
+
+
+def test_add_bracket_after_function(Script):
+    api.settings.add_bracket_after_function = True
+    script = Script('''\
+def foo():
+    pass
+foo''')
+    completions = script.completions()
+    assert completions[0].complete == '('


### PR DESCRIPTION
The type of a completion was compared to "Function" instead of "function" when the add_bracket_after_function flag was checked. This caused add_bracket_after_function to have no effect.