### PR TITLE
Fix transform_path_to_dotted tests on Windows

### DIFF
--- a/jedi/evaluate/sys_path.py
+++ b/jedi/evaluate/sys_path.py
@@ -200,7 +200,8 @@ def transform_path_to_dotted(sys_path, module_path):
     """
     Returns the dotted path inside a sys.path as a list of names. e.g.
 
-    >>> transform_path_to_dotted(["/foo"], '/foo/bar/baz.py')
+    >>> from os.path import abspath
+    >>> transform_path_to_dotted([abspath("/foo")], abspath('/foo/bar/baz.py'))
     ['bar', 'baz']
 
     Returns None if the path doesn't really resolve to anything.

--- a/test/test_evaluate/test_sys_path.py
+++ b/test/test_evaluate/test_sys_path.py
@@ -86,4 +86,7 @@ _s = ['/a', '/b', '/c/d/']
         (_s, '/a/c/.py', None),
     ])
 def test_calculate_dotted_from_path(sys_path_, module_path, result):
+    # tranform_path_to_dotted expects normalized absolute paths.
+    sys_path_ = [os.path.abspath(path) for path in sys_path_]
+    module_path = os.path.abspath(module_path)
     assert sys_path.transform_path_to_dotted(sys_path_, module_path) == result


### PR DESCRIPTION
The  `transform_path_to_dotted` tests fail on Windows because paths with forward slashes are used in the tests while the function operates on paths using `os.path.sep` which is a backslash on Windows. This function should always receive normalized absolute paths so the proper fix is to normalize them in the tests as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/davidhalter/jedi/1300)
<!-- Reviewable:end -->
