### PR TITLE
Fix keyerror

### DIFF
--- a/jedi/evaluate/syntax_tree.py
+++ b/jedi/evaluate/syntax_tree.py
@@ -225,7 +225,7 @@ def eval_atom(context, atom):
             right = eval_atom(context, string)
             context_set = _eval_comparison(context.evaluator, context, context_set, u'+', right)
         return context_set
-    else:
+    elif atom.type == 'atom':
         c = atom.children
         # Parentheses without commas are not tuples.
         if c[0] == '(' and not len(c) == 2 \
@@ -262,6 +262,9 @@ def eval_atom(context, atom):
         else:
             context = iterable.SequenceLiteralContext(context.evaluator, context, atom)
         return ContextSet(context)
+    else:
+        # not a litteral, fall back to evaluating the node
+        return context.eval_node(atom)
 
 
 @_limit_context_infers

--- a/test/completion/basic.py
+++ b/test/completion/basic.py
@@ -312,3 +312,16 @@ with open('') as f1, open('') as f2:
     f1.closed
     #? ['closed']
     f2.closed
+
+
+# -----------------------------
+# power operator with indexing
+# -----------------------------
+
+def square_first(values):
+    return values[0]**2
+
+values = [0]
+#? ['__add__']
+square_first(values).__add__
+


### PR DESCRIPTION
tentative bug fix for issue #1273 : KeyError on SequenceLiteralContext.mapping

Added extra test in `test/completion/basic.py`, test procedure:

```
git checkout master && py.test test/test_integration.py -T basic.py
# result is 1 failed, 57 passed, 2 skipped, 1 warnings in 1.11 seconds
git checkout fix_keyerror && py.test test/test_integration.py -T basic.py
# result is 58 passed, 2 skipped, 1 warnings in 0.99 seconds
```

I try to run the full test suits but I get quite a few failures even on master. Number of failures is 83 on master counting the new test case, 82 on fix_keyerror branch when running `py.test test/test_integration.py`. 