### PR TITLE
get_module_names should include top-level async functions when all_scopes=False.

### DIFF
--- a/jedi/evaluate/helpers.py
+++ b/jedi/evaluate/helpers.py
@@ -190,6 +190,9 @@ def get_module_names(module, all_scopes):
                 # but that would be a big change that could break type inference, whereas for now
                 # this discrepancy looks like only a problem for "get_module_names".
                 parent_scope = parent_scope.parent
+            # async functions have an extra wrapper. Strip it.
+            if parent_scope and parent_scope.type == 'async_stmt':
+                parent_scope = parent_scope.parent
             return parent_scope in (module, None)
 
         names = [n for n in names if is_module_scope_name(n)]

--- a/test/test_api/test_defined_names.py
+++ b/test/test_api/test_defined_names.py
@@ -82,18 +82,34 @@ class TestDefinedNames(TestCase):
     def test_class_fields_with_all_scopes_false(self):
         definitions = self.check_defined_names("""
         from module import f
+        import asyncio
+
         g = f(f)
         class C:
             h = g
+            def __init__(self):
+                pass
+
+            async def __aenter__(self):
+                pass
 
         def foo(x=a):
            bar = x
            return bar
-        """, ['f', 'g', 'C', 'foo'])
-        C_subdefs = definitions[-2].defined_names()
-        foo_subdefs = definitions[-1].defined_names()
-        self.assert_definition_names(C_subdefs, ['h'])
+
+        async def async_foo(duration):
+            async def wait():
+                await asyncio.sleep(100)
+            for i in range(duration//100):
+                await wait()
+            return duration//100*100
+        """, ['f', 'asyncio', 'g', 'C', 'foo', 'async_foo'])
+        C_subdefs = definitions[-3].defined_names()
+        foo_subdefs = definitions[-2].defined_names()
+        async_foo_subdefs = definitions[-1].defined_names()
+        self.assert_definition_names(C_subdefs, ['h', '__init__', '__aenter__'])
         self.assert_definition_names(foo_subdefs, ['x', 'bar'])
+        self.assert_definition_names(async_foo_subdefs, ['duration', 'wait', 'i'])
 
 
 def test_follow_imports(environment):

--- a/test/test_api/test_defined_names.py
+++ b/test/test_api/test_defined_names.py
@@ -82,6 +82,22 @@ class TestDefinedNames(TestCase):
     def test_class_fields_with_all_scopes_false(self):
         definitions = self.check_defined_names("""
         from module import f
+        g = f(f)
+        class C:
+            h = g
+
+        def foo(x=a):
+           bar = x
+           return bar
+        """, ['f', 'g', 'C', 'foo'])
+        C_subdefs = definitions[-2].defined_names()
+        foo_subdefs = definitions[-1].defined_names()
+        self.assert_definition_names(C_subdefs, ['h'])
+        self.assert_definition_names(foo_subdefs, ['x', 'bar'])
+
+    def test_async_stmt_with_all_scopes_false(self):
+        definitions = self.check_defined_names("""
+        from module import f
         import asyncio
 
         g = f(f)
@@ -103,14 +119,19 @@ class TestDefinedNames(TestCase):
             for i in range(duration//100):
                 await wait()
             return duration//100*100
-        """, ['f', 'asyncio', 'g', 'C', 'foo', 'async_foo'])
-        C_subdefs = definitions[-3].defined_names()
-        foo_subdefs = definitions[-2].defined_names()
-        async_foo_subdefs = definitions[-1].defined_names()
+
+        async with C() as cinst:
+            d = cinst
+        """, ['f', 'asyncio', 'g', 'C', 'foo', 'async_foo', 'cinst', 'd'])
+        C_subdefs = definitions[3].defined_names()
+        foo_subdefs = definitions[4].defined_names()
+        async_foo_subdefs = definitions[5].defined_names()
+        cinst_subdefs = definitions[6].defined_names()
         self.assert_definition_names(C_subdefs, ['h', '__init__', '__aenter__'])
         self.assert_definition_names(foo_subdefs, ['x', 'bar'])
         self.assert_definition_names(async_foo_subdefs, ['duration', 'wait', 'i'])
-
+        # We treat d as a name outside `async with` block
+        self.assert_definition_names(cinst_subdefs, [])
 
 def test_follow_imports(environment):
     # github issue #344


### PR DESCRIPTION
ref = #1309 

Skip extra layer of [`async_stmt`](https://github.com/davidhalter/parso/blob/1e25445176185f8ce27460cfa7162c897dd7527b/parso/python/grammar38.txt#L71), so async functions can be treated equally as sync functions.