### PR TITLE
Fix tests on CIs

### DIFF
--- a/jedi/api/classes.py
+++ b/jedi/api/classes.py
@@ -102,6 +102,7 @@ class BaseDefinition(object):
         to Jedi, :meth:`jedi.Script.goto_definitions` should return a list of
         definition for ``sys``, ``f``, ``C`` and ``x``.
 
+        >>> from jedi._compatibility import no_unicode_pprint
         >>> from jedi import Script
         >>> source = '''
         ... import keyword
@@ -127,9 +128,11 @@ class BaseDefinition(object):
         so that it is easy to relate the result to the source code.
 
         >>> defs = sorted(defs, key=lambda d: d.line)
-        >>> defs                           # doctest: +NORMALIZE_WHITESPACE
-        [<Definition module keyword>, <Definition class C>,
-         <Definition instance D>, <Definition def f>]
+        >>> no_unicode_pprint(defs)  # doctest: +NORMALIZE_WHITESPACE
+        [<Definition full_name='keyword', description='module keyword'>,
+         <Definition full_name='__main__.C', description='class C'>,
+         <Definition full_name='__main__.D', description='instance D'>,
+         <Definition full_name='__main__.f', description='def f'>]
 
         Finally, here is what you can get from :attr:`type`:
 
@@ -207,7 +210,7 @@ class BaseDefinition(object):
         >>> source = 'import json'
         >>> script = Script(source, path='example.py')
         >>> d = script.goto_definitions()[0]
-        >>> print(d.module_name)                       # doctest: +ELLIPSIS
+        >>> print(d.module_name)  # doctest: +ELLIPSIS
         json
         """
         return self._get_module().name.string_name
@@ -515,6 +518,7 @@ class Definition(BaseDefinition):
 
         Example:
 
+        >>> from jedi._compatibility import no_unicode_pprint
         >>> from jedi import Script
         >>> source = '''
         ... def f():
@@ -527,8 +531,9 @@ class Definition(BaseDefinition):
         >>> script = Script(source, column=3)  # line is maximum by default
         >>> defs = script.goto_definitions()
         >>> defs = sorted(defs, key=lambda d: d.line)
-        >>> defs
-        [<Definition def f>, <Definition class C>]
+        >>> no_unicode_pprint(defs)  # doctest: +NORMALIZE_WHITESPACE
+        [<Definition full_name='__main__.f', description='def f'>,
+         <Definition full_name='__main__.C', description='class C'>]
         >>> str(defs[0].description)  # strip literals in python2
         'def f'
         >>> str(defs[1].description)

--- a/jedi/evaluate/filters.py
+++ b/jedi/evaluate/filters.py
@@ -359,10 +359,11 @@ def get_global_filters(evaluator, context, until_position, origin_scope):
 
     First we get the names from the function scope.
 
-    >>> no_unicode_pprint(filters[0])                    #doctest: +ELLIPSIS
+    >>> no_unicode_pprint(filters[0])  # doctest: +ELLIPSIS
     MergedFilter(<ParserTreeFilter: ...>, <GlobalNameFilter: ...>)
-    >>> sorted(str(n) for n in filters[0].values())
-    ['<TreeNameDefinition: func@(3, 4)>', '<TreeNameDefinition: x@(2, 0)>']
+    >>> sorted(str(n) for n in filters[0].values())  # doctest: +NORMALIZE_WHITESPACE
+    ['<TreeNameDefinition: string_name=func start_pos=(3, 4)>',
+     '<TreeNameDefinition: string_name=x start_pos=(2, 0)>']
     >>> filters[0]._filters[0]._until_position
     (4, 0)
     >>> filters[0]._filters[1]._until_position
@@ -380,7 +381,7 @@ def get_global_filters(evaluator, context, until_position, origin_scope):
     Finally, it yields the builtin filter, if `include_builtin` is
     true (default).
 
-    >>> list(filters[3].values())                        #doctest: +ELLIPSIS
+    >>> list(filters[3].values())  # doctest: +ELLIPSIS
     [...]
     """
     from jedi.evaluate.context.function import FunctionExecutionContext

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -13,13 +13,19 @@ else:
 TestCase = unittest.TestCase
 
 import os
+import pytest
 from os.path import abspath, dirname, join
-import functools
+from functools import partial, wraps
 
 test_dir = dirname(abspath(__file__))
 root_dir = dirname(test_dir)
 
 sample_int = 1  # This is used in completion/imports.py
+
+skip_if_windows = partial(pytest.param,
+                          marks=pytest.mark.skipif("sys.platform=='win32'"))
+skip_if_not_windows = partial(pytest.param,
+                              marks=pytest.mark.skipif("sys.platform!='win32'"))
 
 
 def get_example_dir(name):
@@ -34,7 +40,7 @@ def cwd_at(path):
     :arg  path: relative path from repository root (e.g., ``'jedi'``).
     """
     def decorator(func):
-        @functools.wraps(func)
+        @wraps(func)
         def wrapper(Script, **kwargs):
             with set_cwd(path):
                 return func(Script, **kwargs)

--- a/test/test_evaluate/test_imports.py
+++ b/test/test_evaluate/test_imports.py
@@ -38,7 +38,9 @@ def test_find_module_not_package():
     assert is_package is False
 
 
-pkg_zip_path = os.path.join(os.path.dirname(__file__), 'zipped_imports/pkg.zip')
+pkg_zip_path = os.path.join(os.path.dirname(__file__),
+                            'zipped_imports',
+                            'pkg.zip')
 
 
 def test_find_module_package_zipped(Script, evaluator, environment):

--- a/test/test_evaluate/test_sys_path.py
+++ b/test/test_evaluate/test_sys_path.py
@@ -4,6 +4,7 @@ import sys
 import shutil
 
 import pytest
+from ..helpers import skip_if_windows, skip_if_not_windows
 
 from jedi.evaluate import sys_path
 from jedi.api.environment import create_environment
@@ -87,8 +88,12 @@ _s = ['/a', '/b', '/c/d/']
 
         (['/foo'], '/foo/bar/__init__.py', ('bar',), True),
         (['/foo'], '/foo/bar/baz/__init__.py', ('bar', 'baz'), True),
-        (['/foo'], '/foo/bar.so', ('bar',), False),
-        (['/foo'], '/foo/bar/__init__.so', ('bar',), True),
+
+        skip_if_windows(['/foo'], '/foo/bar.so', ('bar',), False),
+        skip_if_windows(['/foo'], '/foo/bar/__init__.so', ('bar',), True),
+        skip_if_not_windows(['/foo'], '/foo/bar.pyd', ('bar',), False),
+        skip_if_not_windows(['/foo'], '/foo/bar/__init__.pyd', ('bar',), True),
+
         (['/foo'], '/x/bar.py', None, False),
         (['/foo'], '/foo/bar.xyz', ('bar.xyz',), False),
 

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,8 @@ deps =
     py34: typing
 # numpydoc for typing scipy stack
     numpydoc
+# sphinx, a dependency of numpydoc, dropped Python 2 support in version 2.0
+    sphinx < 2.0
     cov: coverage
 # Overwrite the parso version (only used sometimes).
 #     git+https://github.com/davidhalter/parso.git


### PR DESCRIPTION
This PR fixes tests that are failing on Travis and AppVeyor because of the following points:
 - wrong path separator in the `pkg_zip_path` variable (which is used in the `correct_zip_package_behavior` tests) on Windows;
 - compiled modules using a different extension on Windows (`.pyd` instead of `.so`);
 - change in the representation of the `AbstractNameDefinition` class, breaking a few docstring tests;
 - version 2.0 of Sphinx (which is a dependency of numpydoc) dropped Python 2 support.

There are still tests failing locally on my machine with Python 2 but I didn't bother trying to fix them since it's Python 2 and they are passing on AppVeyor.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/davidhalter/jedi/1326)
<!-- Reviewable:end -->
