### PR TITLE
Use scandir on py3.5+ for less disk access on filename completion

### DIFF
--- a/jedi/_compatibility.py
+++ b/jedi/_compatibility.py
@@ -27,6 +27,27 @@ is_py35 = is_py3 and sys.version_info[1] >= 5
 py_version = int(str(sys.version_info[0]) + str(sys.version_info[1]))
 
 
+if is_py35:
+    """
+    A super-minimal shim around listdir that behave like
+    scandir for the information we need.
+    """
+    class _DirEntry:
+
+        def __init__(self, name, basepath):
+            self.name = name
+            self.basepath = basepath
+
+        def is_dir(self):
+            path_for_name = os.path.join(self.basepath, self.name)
+            return os.path.isdir(path_for_name)
+
+    def scandir(dir):
+        return [_DirEntry(name, dir) for name in os.listdir(dir)]
+else:
+    from os import scandir
+
+
 class DummyFile(object):
     def __init__(self, loader, string):
         self.loader = loader

--- a/jedi/_compatibility.py
+++ b/jedi/_compatibility.py
@@ -27,7 +27,7 @@ is_py35 = is_py3 and sys.version_info[1] >= 5
 py_version = int(str(sys.version_info[0]) + str(sys.version_info[1]))
 
 
-if is_py35:
+if sys.version_info[:2] < (3, 5):
     """
     A super-minimal shim around listdir that behave like
     scandir for the information we need.


### PR DESCRIPTION
On Python 3.5+, we can make use of scandir that not only list the
content of the directory as an iterator but caches some infomations (for
example, `is_dir()`; this avoid extra stats call to the underlying
filesytem and can be – according to pep 471 –  2x to 20 time faster
especially on NFS filesystem where stats call is expensive.

From a quick this is the only place where scandir would make sens, as
most other places only require the name.

Fixes #1381