### PR TITLE
Complete path after ~.

### DIFF
--- a/jedi/api/file_name.py
+++ b/jedi/api/file_name.py
@@ -37,6 +37,8 @@ def file_name_completions(evaluator, module_context, start_leaf, string,
     like_name_length = len(os.path.basename(string) + like_name)
 
     addition = _get_string_additions(module_context, start_leaf)
+    if string.startswith('~'):
+        string = os.path.expanduser(string)
     if addition is None:
         return
     string = addition + string

--- a/test/test_api/test_completion.py
+++ b/test/test_api/test_completion.py
@@ -1,4 +1,5 @@
-from os.path import join, sep as s
+from os.path import join, sep as s, expanduser
+import os
 import sys
 from textwrap import dedent
 
@@ -82,6 +83,14 @@ def test_loading_unicode_files_with_bad_global_charset(Script, monkeypatch, tmpd
     s = Script("from test1 import foo\nfoo.",
                line=2, column=4, path=filename2)
     s.completions()
+
+def test_complete_expanduser(Script):
+    possibilities = os.listdir(expanduser('~'))
+    non_dots = [p for p in possibilities if not p.startswith('.') and len(p) > 1]
+    item = non_dots[0]
+    line = "'~%s%s'" % (os.sep, item)
+    s = Script(line, line=1, column=len(line)-1)
+    assert item in [c.name for c in s.completions()]
 
 
 def test_fake_subnodes(Script):


### PR DESCRIPTION
Note this is mostly to discuss as if I understood one of your message on
Twitter, this was not possible without fuzzy completion.

I tried with just this patch and that works great.

Note that unlike IPython that right now does :

    ~/<tab> -> /Full/Path/to/user/home

But with this patch this just complete things correctly without
expanding the tab. And I think not expanding the tab is actually better.

Anyway, open that to better understand the why you were waiting for
fuzzy completion.