### PR TITLE
Add API to find the virtual_env of single venv path

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -53,5 +53,6 @@ micbou (@micbou)
 Dima Gerasimov (@karlicoss) <karlicoss@gmail.com>
 Max Woerner Chase (@mwchase) <max.chase@gmail.com>
 Johannes Maria Frank (@jmfrank63) <jmfrank63@gmail.com>
+Sinkerine (@15cm) <i@15cm.net>
 
 Note: (@user) means a github user name.

--- a/jedi/api/environment.py
+++ b/jedi/api/environment.py
@@ -251,6 +251,15 @@ def _get_cached_default_environment():
     return get_default_environment()
 
 
+def find_virtualenv(path, safe=True):
+    if os.path.isdir(path):
+        try:
+            executable = _get_executable_path(path, safe=safe)
+            return Environment(executable)
+        except InvalidPythonEnvironment:
+            pass
+
+
 def find_virtualenvs(paths=None, **kwargs):
     """
     :param paths: A list of paths in your file system to be scanned for
@@ -290,11 +299,9 @@ def find_virtualenvs(paths=None, **kwargs):
                     continue
                 _used_paths.add(path)
 
-                try:
-                    executable = _get_executable_path(path, safe=safe)
-                    yield Environment(executable)
-                except InvalidPythonEnvironment:
-                    pass
+                virtual_env = find_virtualenv(path, safe)
+                if virtual_env:
+                    yield virtual_env
 
     return py27_comp(paths, **kwargs)
 


### PR DESCRIPTION
Extract a `find_virtualenv` function to find single venv with given path. This function provides the API for _pyenv_ support in _python-language-server_: [Support pyenv virtualenv for LSP project roots ](https://github.com/15cm/python-language-server/commit/e3433c891dbce8131de005a3b9e4dba586bc8a33)