### PR TITLE
Added #827 experimental fuzzysearch

### DIFF
--- a/jedi/api/__init__.py
+++ b/jedi/api/__init__.py
@@ -201,7 +201,7 @@ class Script(object):
             self._inference_state.environment,
         )
 
-    def completions(self, fuzzy=False):
+    def completions(self, fuzzy=True):
         """
         Return :class:`classes.Completion` objects. Those objects contain
         information about the completions, more than just names.

--- a/jedi/api/__init__.py
+++ b/jedi/api/__init__.py
@@ -201,7 +201,7 @@ class Script(object):
             self._inference_state.environment,
         )
 
-    def completions(self, fuzzy=True):
+    def completions(self, fuzzy=False):
         """
         Return :class:`classes.Completion` objects. Those objects contain
         information about the completions, more than just names.

--- a/jedi/api/__init__.py
+++ b/jedi/api/__init__.py
@@ -201,7 +201,7 @@ class Script(object):
             self._inference_state.environment,
         )
 
-    def completions(self):
+    def completions(self, fuzzy=False):
         """
         Return :class:`classes.Completion` objects. Those objects contain
         information about the completions, more than just names.
@@ -214,7 +214,7 @@ class Script(object):
                 self._inference_state, self._get_module_context(), self._code_lines,
                 self._pos, self.call_signatures
             )
-            return completion.completions()
+            return completion.completions(fuzzy)
 
     def goto_definitions(self, **kwargs):
         """

--- a/jedi/api/completion.py
+++ b/jedi/api/completion.py
@@ -27,18 +27,6 @@ def get_call_signature_param_names(call_signatures):
                                       Parameter.KEYWORD_ONLY):
                 yield p._name
 
-def start_match(string, like_name):
-    return string.startswith(like_name)
-
-
-def fuzzy_match(string, like_name):
-    if len(like_name) <= 1:
-        return like_name in string
-    pos = string.find(like_name[0])
-    if pos >= 0:
-        return fuzzy_match(string[pos + 1:], like_name[1:])
-    return False
-
 
 def filter_names(inference_state, completion_names, stack, like_name, fuzzy):
     comp_dct = {}
@@ -49,9 +37,9 @@ def filter_names(inference_state, completion_names, stack, like_name, fuzzy):
         if settings.case_insensitive_completion:
             string = string.lower()
         if fuzzy:
-            match = fuzzy_match(string, like_name)
+            match = helpers.fuzzy_match(string, like_name)
         else:
-            match = start_match(string, like_name)
+            match = helpers.start_match(string, like_name)
         if match:
             new = classes.Completion(
                 inference_state,
@@ -111,7 +99,8 @@ class Completion:
             completions = list(file_name_completions(
                 self._inference_state, self._module_context, start_leaf, string,
                 self._like_name, self._call_signatures_callback,
-                self._code_lines, self._original_position
+                self._code_lines, self._original_position,
+                fuzzy
             ))
             if completions:
                 return completions

--- a/jedi/api/completion.py
+++ b/jedi/api/completion.py
@@ -27,6 +27,22 @@ def get_call_signature_param_names(call_signatures):
                                       Parameter.KEYWORD_ONLY):
                 yield p._name
 
+def start_match(string, like_name):
+    return string.startswith(like_name)
+
+
+def substr_match(string, like_name):
+    return like_name in string
+
+
+def fuzzy_match(string, like_name):
+    if len(like_name) <= 1:
+        return like_name in string
+    pos = string.find(like_name[0])
+    if pos >= 0:
+        return fuzzy_match(string[pos + 1:], like_name[1:])
+    return False
+
 
 def filter_names(inference_state, completion_names, stack, like_name):
     comp_dct = {}
@@ -37,7 +53,7 @@ def filter_names(inference_state, completion_names, stack, like_name):
         if settings.case_insensitive_completion:
             string = string.lower()
 
-        if string.startswith(like_name):
+        if fuzzy_match(string, like_name):
             new = classes.Completion(
                 inference_state,
                 name,

--- a/jedi/api/completion.py
+++ b/jedi/api/completion.py
@@ -85,7 +85,7 @@ def get_flow_scope_node(module_node, position):
 
 class Completion:
     def __init__(self, inference_state, module_context, code_lines, position,
-                 call_signatures_callback):
+                 call_signatures_callback, fuzzy=False):
         self._inference_state = inference_state
         self._module_context = module_context
         self._module_node = module_context.tree_node
@@ -99,10 +99,12 @@ class Completion:
         self._position = position[0], position[1] - len(self._like_name)
         self._call_signatures_callback = call_signatures_callback
 
-    def completions(self, **kwargs):
-        return self._completions(**kwargs)
+        self._fuzzy = fuzzy
 
-    def _completions(self, fuzzy=False):
+    def completions(self, fuzzy=False, **kwargs):
+        return self._completions(fuzzy, **kwargs)
+
+    def _completions(self, fuzzy):
         leaf = self._module_node.get_leaf_for_position(self._position, include_prefixes=True)
         string, start_leaf = _extract_string_while_in_string(leaf, self._position)
         if string is not None:

--- a/jedi/api/file_name.py
+++ b/jedi/api/file_name.py
@@ -33,7 +33,7 @@ def file_name_completions(inference_state, module_context, start_leaf, string,
             string = to_be_added + string
     base_path = os.path.join(inference_state.project._path, string)
     try:
-        listed = scandir(base_path)
+        listed = sorted(scandir(base_path), key=lambda e:e.name)
     except FileNotFoundError:
         return
     for entry in listed:

--- a/jedi/api/file_name.py
+++ b/jedi/api/file_name.py
@@ -3,12 +3,13 @@ import os
 from jedi._compatibility import FileNotFoundError, force_unicode, scandir
 from jedi.inference.names import AbstractArbitraryName
 from jedi.api import classes
+from jedi.api.helpers import fuzzy_match, start_match
 from jedi.inference.helpers import get_str_or_none
 from jedi.parser_utils import get_string_quote
 
 
 def file_name_completions(inference_state, module_context, start_leaf, string,
-                          like_name, call_signatures_callback, code_lines, position):
+                          like_name, call_signatures_callback, code_lines, position, fuzzy):
     # First we want to find out what can actually be changed as a name.
     like_name_length = len(os.path.basename(string) + like_name)
 
@@ -37,7 +38,11 @@ def file_name_completions(inference_state, module_context, start_leaf, string,
         return
     for entry in listed:
         name = entry.name
-        if name.startswith(must_start_with):
+        if fuzzy:
+            match = fuzzy_match(name, must_start_with)
+        else:
+            match = start_match(name, must_start_with)
+        if match:
             if is_in_os_path_join or not entry.is_dir():
                 if start_leaf.type == 'string':
                     quote = get_string_quote(start_leaf)

--- a/jedi/api/helpers.py
+++ b/jedi/api/helpers.py
@@ -19,6 +19,19 @@ from jedi.cache import call_signature_time_cache
 CompletionParts = namedtuple('CompletionParts', ['path', 'has_dot', 'name'])
 
 
+def start_match(string, like_name):
+    return string.startswith(like_name)
+
+
+def fuzzy_match(string, like_name):
+    if len(like_name) <= 1:
+        return like_name in string
+    pos = string.find(like_name[0])
+    if pos >= 0:
+        return fuzzy_match(string[pos + 1:], like_name[1:])
+    return False
+
+
 def sorted_definitions(defs):
     # Note: `or ''` below is required because `module_path` could be
     return sorted(defs, key=lambda x: (x.module_path or '', x.line or 0, x.column or 0, x.name))

--- a/jedi/api/replstartup.py
+++ b/jedi/api/replstartup.py
@@ -21,7 +21,7 @@ import jedi.utils
 from jedi import __version__ as __jedi_version__
 
 print('REPL completion using Jedi %s' % __jedi_version__)
-jedi.utils.setup_readline()
+jedi.utils.setup_readline(fuzzy=False)
 
 del jedi
 

--- a/jedi/utils.py
+++ b/jedi/utils.py
@@ -17,7 +17,7 @@ from jedi import Interpreter
 READLINE_DEBUG = False
 
 
-def setup_readline(namespace_module=__main__):
+def setup_readline(namespace_module=__main__, fuzzy=False):
     """
     Install Jedi completer to :mod:`readline`.
 
@@ -83,7 +83,7 @@ def setup_readline(namespace_module=__main__):
                     logging.debug("Start REPL completion: " + repr(text))
                     interpreter = Interpreter(text, [namespace_module.__dict__])
 
-                    completions = interpreter.completions()
+                    completions = interpreter.completions(fuzzy=fuzzy)
                     logging.debug("REPL completions: %s", completions)
 
                     self.matches = [

--- a/test/test_api/test_api.py
+++ b/test/test_api/test_api.py
@@ -317,13 +317,13 @@ def test_str_fuzzy_completion(Script):
                     reason="requires python3.3 or higher")
 def test_math_fuzzy_completion(Script):
     script = Script('import math\nmath.og')
-    assert ['copysign', 'log', 'log10',
-            'log1p'] == [comp.name for comp in script.completions(fuzzy=True)]
+    assert ['copysign', 'log', 'log10', 'log1p',
+            'log2'] == [comp.name for comp in script.completions(fuzzy=True)]
 
 
 @pytest.mark.skipif(sys.version_info >= (3, 3),
                     reason="requires python3.3 or higher")
 def test_math_fuzzy_completion(Script):
     script = Script('import math\nmath.og')
-    assert ['copysign', 'log', 'log10', 'log1p',
-            'log2'] == [comp.name for comp in script.completions(fuzzy=True)]
+    assert ['copysign', 'log', 'log10',
+            'log1p'] == [comp.name for comp in script.completions(fuzzy=True)]

--- a/test/test_api/test_api.py
+++ b/test/test_api/test_api.py
@@ -321,7 +321,7 @@ def test_math_fuzzy_completion(Script):
             'log2'] == [comp.name for comp in script.completions(fuzzy=True)]
 
 
-@pytest.mark.skipif(sys.version_info >= (3, 3),
+@pytest.mark.skipif(sys.version_info > (2, 7),
                     reason="requires python3.3 or higher")
 def test_math_fuzzy_completion(Script):
     script = Script('import math\nmath.og')

--- a/test/test_api/test_api.py
+++ b/test/test_api/test_api.py
@@ -304,3 +304,10 @@ def test_goto_follow_builtin_imports(Script):
     assert d.in_builtin_module() is True
     d, = s.goto_assignments(follow_imports=True, follow_builtin_imports=True)
     assert d.in_builtin_module() is True
+
+
+def test_fuzzy_completion(Script):
+    script = Script('string =  "hello"\nstring.upper')
+    assert ['isupper', 'upper'] == [comp.name 
+                                    for comp in 
+                                    script.completions(fuzzy=True)]

--- a/test/test_api/test_api.py
+++ b/test/test_api/test_api.py
@@ -306,6 +306,18 @@ def test_goto_follow_builtin_imports(Script):
     assert d.in_builtin_module() is True
 
 
+def test_file_fuzzy_completion(Script, tmp_path):
+    folder0 = tmp_path / "inference"
+    folder0.mkdir()
+    file0_path0 = folder0 / "sys_path.py"
+    file0_path0.write_text('\n')
+    file0_path1 = folder0 / "syntax_tree.py"
+    file0_path1.write_text('\n')
+    script = Script('"{}/yt'.format(folder0))
+    assert ['sys_path.py"', 
+            'syntax_tree.py"' ] == [comp.name for comp in script.completions(fuzzy=True)]
+
+
 def test_fuzzy_completion(Script):
     script = Script('string =  "hello"\nstring.upper')
     assert ['isupper',
@@ -326,3 +338,5 @@ def test_math_fuzzy_completion(Script):
     script = Script('import math\nmath.og')
     assert ['copysign', 'log', 'log10',
             'log1p'] == [comp.name for comp in script.completions(fuzzy=True)]
+
+

--- a/test/test_api/test_api.py
+++ b/test/test_api/test_api.py
@@ -23,7 +23,8 @@ def test_preload_modules():
         # Filter the typeshed parser cache.
         typeshed_cache_count = sum(
             1 for path in grammar_cache
-            if path is not None and path.startswith(typeshed.TYPESHED_PATH))
+            if path is not None and path.startswith(typeshed.TYPESHED_PATH)
+        )
         # +1 for None module (currently used)
         assert len(grammar_cache) - typeshed_cache_count == len(modules) + 1
         for i in modules:
@@ -34,8 +35,7 @@ def test_preload_modules():
 
     try:
         preload_module('sys')
-        check_loaded(
-        )  # compiled (c_builtin) modules shouldn't be in the cache.
+        check_loaded()  # compiled (c_builtin) modules shouldn't be in the cache.
         preload_module('types', 'token')
         check_loaded('types', 'token')
     finally:
@@ -117,9 +117,8 @@ def test_completion_on_complex_literals(Script):
     # However this has been disabled again, because it apparently annoyed
     # users. So no completion after j without a space :)
     assert not Script('4j').completions()
-    assert ({c.name
-             for c in Script('4j ').completions()
-             } == {'if', 'and', 'in', 'is', 'not', 'or'})
+    assert ({c.name for c in Script('4j ').completions()} ==
+            {'if', 'and', 'in', 'is', 'not', 'or'})
 
 
 def test_goto_assignments_on_non_name(Script, environment):
@@ -168,8 +167,7 @@ def test_usage_description(Script):
 
 def test_get_line_code(Script):
     def get_line_code(source, line=None, **kwargs):
-        return Script(source,
-                      line=line).completions()[0].get_line_code(**kwargs)
+        return Script(source, line=line).completions()[0].get_line_code(**kwargs)
 
     # On builtin
     assert get_line_code('') == ''
@@ -246,7 +244,8 @@ def test_goto_definition_cursor(Script):
          "                   b):\n"
          "        return\n"
          "A._something\n"
-         "A.different_line")
+         "A.different_line"
+         )
 
     in_name = 2, 9
     under_score = 2, 8
@@ -307,7 +306,7 @@ def test_goto_follow_builtin_imports(Script):
     assert d.in_builtin_module() is True
 
 
-def test_str_fuzzy_completion(Script):
+def test_fuzzy_completion(Script):
     script = Script('string =  "hello"\nstring.upper')
     assert ['isupper',
             'upper'] == [comp.name for comp in script.completions(fuzzy=True)]

--- a/test/test_api/test_api.py
+++ b/test/test_api/test_api.py
@@ -307,10 +307,23 @@ def test_goto_follow_builtin_imports(Script):
     assert d.in_builtin_module() is True
 
 
-def test_fuzzy_completion(Script):
+def test_str_fuzzy_completion(Script):
     script = Script('string =  "hello"\nstring.upper')
     assert ['isupper',
             'upper'] == [comp.name for comp in script.completions(fuzzy=True)]
+
+
+@pytest.mark.skipif(sys.version_info < (3, 3),
+                    reason="requires python3.3 or higher")
+def test_math_fuzzy_completion(Script):
+    script = Script('import math\nmath.og')
+    assert ['copysign', 'log', 'log10',
+            'log1p'] == [comp.name for comp in script.completions(fuzzy=True)]
+
+
+@pytest.mark.skipif(sys.version_info >= (3, 3),
+                    reason="requires python3.3 or higher")
+def test_math_fuzzy_completion(Script):
     script = Script('import math\nmath.og')
     assert ['copysign', 'log', 'log10', 'log1p',
             'log2'] == [comp.name for comp in script.completions(fuzzy=True)]

--- a/test/test_api/test_api.py
+++ b/test/test_api/test_api.py
@@ -306,18 +306,6 @@ def test_goto_follow_builtin_imports(Script):
     assert d.in_builtin_module() is True
 
 
-def test_file_fuzzy_completion(Script, tmp_path):
-    folder0 = tmp_path / "inference"
-    folder0.mkdir()
-    file0_path0 = folder0 / "sys_path.py"
-    file0_path0.write_text('\n')
-    file0_path1 = folder0 / "syntax_tree.py"
-    file0_path1.write_text('\n')
-    script = Script('"{}/yt'.format(folder0))
-    assert ['syntax_tree.py"', 
-            'sys_path.py"'] == [comp.name for comp in script.completions(fuzzy=True)]
-
-
 def test_fuzzy_completion(Script):
     script = Script('string =  "hello"\nstring.upper')
     assert ['isupper',
@@ -331,6 +319,19 @@ def test_math_fuzzy_completion(Script):
     assert ['copysign', 'log', 'log10', 'log1p',
             'log2'] == [comp.name for comp in script.completions(fuzzy=True)]
 
+@pytest.mark.skipif(sys.version_info < (3, 3),
+                    reason="requires python3.3 or higher")
+def test_file_fuzzy_completion(Script, tmp_path):
+    folder0 = tmp_path / "inference"
+    folder0.mkdir()
+    file0_path0 = folder0 / "sys_path.py"
+    file0_path0.write_text('\n')
+    file0_path1 = folder0 / "syntax_tree.py"
+    file0_path1.write_text('\n')
+    script = Script('"{}/yt'.format(folder0))
+    assert ['syntax_tree.py"', 
+            'sys_path.py"'] == [comp.name for comp in script.completions(fuzzy=True)]
+
 
 @pytest.mark.skipif(sys.version_info > (2, 7),
                     reason="requires python3.3 or higher")
@@ -339,4 +340,16 @@ def test_math_fuzzy_completion(Script):
     assert ['copysign', 'log', 'log10',
             'log1p'] == [comp.name for comp in script.completions(fuzzy=True)]
 
+@pytest.mark.skipif(sys.version_info > (2, 7),
+                    reason="requires python3.3 or higher")
+def test_file_fuzzy_completion(Script, tmp_path):
+    folder0 = tmp_path / u"inference"
+    folder0.mkdir()
+    file0_path0 = folder0 / u"sys_path.py"
+    file0_path0.write_text('\n')
+    file0_path1 = folder0 / u"syntax_tree.py"
+    file0_path1.write_text('\n')
+    script = Script('"{}/yt'.format(folder0))
+    assert ['syntax_tree.py"', 
+            'sys_path.py"'] == [comp.name for comp in script.completions(fuzzy=True)]
 

--- a/test/test_api/test_api.py
+++ b/test/test_api/test_api.py
@@ -314,8 +314,8 @@ def test_file_fuzzy_completion(Script, tmp_path):
     file0_path1 = folder0 / "syntax_tree.py"
     file0_path1.write_text('\n')
     script = Script('"{}/yt'.format(folder0))
-    assert ['sys_path.py"', 
-            'syntax_tree.py"' ] == [comp.name for comp in script.completions(fuzzy=True)]
+    assert ['syntax_tree.py"', 
+            'sys_path.py"'] == [comp.name for comp in script.completions(fuzzy=True)]
 
 
 def test_fuzzy_completion(Script):

--- a/test/test_api/test_api.py
+++ b/test/test_api/test_api.py
@@ -23,8 +23,7 @@ def test_preload_modules():
         # Filter the typeshed parser cache.
         typeshed_cache_count = sum(
             1 for path in grammar_cache
-            if path is not None and path.startswith(typeshed.TYPESHED_PATH)
-        )
+            if path is not None and path.startswith(typeshed.TYPESHED_PATH))
         # +1 for None module (currently used)
         assert len(grammar_cache) - typeshed_cache_count == len(modules) + 1
         for i in modules:
@@ -35,7 +34,8 @@ def test_preload_modules():
 
     try:
         preload_module('sys')
-        check_loaded()  # compiled (c_builtin) modules shouldn't be in the cache.
+        check_loaded(
+        )  # compiled (c_builtin) modules shouldn't be in the cache.
         preload_module('types', 'token')
         check_loaded('types', 'token')
     finally:
@@ -117,8 +117,9 @@ def test_completion_on_complex_literals(Script):
     # However this has been disabled again, because it apparently annoyed
     # users. So no completion after j without a space :)
     assert not Script('4j').completions()
-    assert ({c.name for c in Script('4j ').completions()} ==
-            {'if', 'and', 'in', 'is', 'not', 'or'})
+    assert ({c.name
+             for c in Script('4j ').completions()
+             } == {'if', 'and', 'in', 'is', 'not', 'or'})
 
 
 def test_goto_assignments_on_non_name(Script, environment):
@@ -167,7 +168,8 @@ def test_usage_description(Script):
 
 def test_get_line_code(Script):
     def get_line_code(source, line=None, **kwargs):
-        return Script(source, line=line).completions()[0].get_line_code(**kwargs)
+        return Script(source,
+                      line=line).completions()[0].get_line_code(**kwargs)
 
     # On builtin
     assert get_line_code('') == ''
@@ -244,8 +246,7 @@ def test_goto_definition_cursor(Script):
          "                   b):\n"
          "        return\n"
          "A._something\n"
-         "A.different_line"
-         )
+         "A.different_line")
 
     in_name = 2, 9
     under_score = 2, 8
@@ -308,6 +309,8 @@ def test_goto_follow_builtin_imports(Script):
 
 def test_fuzzy_completion(Script):
     script = Script('string =  "hello"\nstring.upper')
-    assert ['isupper', 'upper'] == [comp.name 
-                                    for comp in 
-                                    script.completions(fuzzy=True)]
+    assert ['isupper',
+            'upper'] == [comp.name for comp in script.completions(fuzzy=True)]
+    script = Script('import math\nmath.og')
+    assert ['copysign', 'log', 'log10', 'log1p',
+            'log2'] == [comp.name for comp in script.completions(fuzzy=True)]

--- a/test/test_api/test_completion.py
+++ b/test/test_api/test_completion.py
@@ -267,3 +267,18 @@ def test_file_path_completions(Script, file, code, column, expected):
         assert len(comps) > 100  # This is basically global completions.
     else:
         assert [c.complete for c in comps] == expected
+
+from jedi.api.completion import start_match, substr_match, fuzzy_match
+
+def test_start_match():
+    assert start_match('Condition', 'C')
+    
+def test_substr_match():
+    assert substr_match('Condition', 'dit')
+
+def test_fuzzy_match():
+    assert fuzzy_match('Condition', 'i')
+    assert not fuzzy_match('Condition', 'p')
+    assert fuzzy_match('Condition', 'ii')
+    assert not fuzzy_match('Condition', 'Ciito')
+    assert fuzzy_match('Condition', 'Cdiio')

--- a/test/test_api/test_completion.py
+++ b/test/test_api/test_completion.py
@@ -268,7 +268,7 @@ def test_file_path_completions(Script, file, code, column, expected):
     else:
         assert [c.complete for c in comps] == expected
 
-from jedi.api.completion import start_match, fuzzy_match
+from jedi.api.helpers import start_match, fuzzy_match
 
 def test_start_match():
     assert start_match('Condition', 'C')

--- a/test/test_api/test_completion.py
+++ b/test/test_api/test_completion.py
@@ -268,14 +268,11 @@ def test_file_path_completions(Script, file, code, column, expected):
     else:
         assert [c.complete for c in comps] == expected
 
-from jedi.api.completion import start_match, substr_match, fuzzy_match
+from jedi.api.completion import start_match, fuzzy_match
 
 def test_start_match():
     assert start_match('Condition', 'C')
     
-def test_substr_match():
-    assert substr_match('Condition', 'dit')
-
 def test_fuzzy_match():
     assert fuzzy_match('Condition', 'i')
     assert not fuzzy_match('Condition', 'p')


### PR DESCRIPTION
@davidhalter I deviated from the regex approach in favor of a recursive parsing. Since completion strings are usually limited in length this should be fairly fast. Interestingly I spend about 80% of my time getting the tool chain to work. Currently my local tests fail miserably for I cannot persuade tox to use my local parso clone.
But independent of this please take a look at the (surprisingly) small fuzzy_search function. A shallow test with fzf seemed to show the same behaviour. If you type a character it shows only those strings that contain the character. The next character will only be considered if it is following the first and so on. You can therefore search Condition by typing cdn or dtn. I think this is what is wanted.
Let me know your thoughts.