### PR TITLE
Support anaconda system env

### DIFF
--- a/jedi/api/environment.py
+++ b/jedi/api/environment.py
@@ -361,7 +361,11 @@ def _get_executable_path(path, safe=True):
     """
 
     if os.name == 'nt':
-        python = os.path.join(path, 'Scripts', 'python.exe')
+        intermediate_folders = ['Scripts', 'anaconda3']
+        for folder in intermediate_folders:
+            python = os.path.join(path, folder, 'python.exe')
+            if os.path.exists(python):
+                break
     else:
         python = os.path.join(path, 'bin', 'python')
     if not os.path.exists(python):


### PR DESCRIPTION
## Context

I am the current maintainer of [Elpy](https://github.com/jorgenschaefer/elpy).
We use jedi to provide completion, access to the documentation, etc... (all the nice things).

To avoid having to ask every user to install jedi systemwide, we run jedi in a dedicated virtual environment ('running virtualenv') and specify the environment to work on ('working environment') through the `environment` argument: 
```
env = jedi.create_environment("/path/to/working-environment")
script = jedi.Script(..., environment=env, ...)
```

It works very nicely when the working environment is a virtual one.
When the working environment is the system environment itself, we provide a path that looks like this: `env = jedi.create_environment("/usr")`, so that jedi can find the binaries in `/usr/bin/python`.

(Please let me know if we are not supposed to use jedi like this)

## Problem

On windows and with Anaconda (I don't know if it is happening with other OS/python distributions), the system python binaries are stored under `.../Continuum/anaconda3/python.exe`.
Using `env = jedi.create_environment(".../Continuum")` does not work, as jedi is only looking for python binaries under a `Scripts` folder.

## Proposed solution

This PR just modifies the `_get_executable_path()` function to check for python binaries under a `anaconda3` folder as well on Windows.

I can add a few tests if you think this PR is relevant.

If I managed to keep you interested until this point, I will take the opportunity to thank you for Jedi, it is a wonderful tool to work with !