### PR TITLE
Fix annotation string generated from wrong object

### DIFF
--- a/jedi/inference/compiled/access.py
+++ b/jedi/inference/compiled/access.py
@@ -433,7 +433,7 @@ class DirectObjectAccess(object):
                 default_string=repr(p.default),
                 has_annotation=p.annotation is not p.empty,
                 annotation=self._create_access_path(p.annotation),
-                annotation_string=str(p.default),
+                annotation_string=str(p.annotation),
                 kind_name=str(p.kind)
             ) for p in self._get_signature().parameters.values()
         ]


### PR DESCRIPTION
For `inspect.Parameter` objects
`'clip': <Parameter "clip: vapoursynth.VideoNode">`
`'width': <Parameter "width: Union[int, NoneType] = None">`
created from compiled object, jedi unexpectedly outputted
`clip: <class 'inspect._empty'>`
`width: None=None`
in call signature. With this PR applied, output is expected
`clip: <class 'vapoursynth.VideoNode'>`
`width: typing.Union[int, NoneType]=None`