### PR TITLE
Find active conda environment and set it as default (if there is one)

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -53,5 +53,6 @@ micbou (@micbou)
 Dima Gerasimov (@karlicoss) <karlicoss@gmail.com>
 Max Woerner Chase (@mwchase) <max.chase@gmail.com>
 Johannes Maria Frank (@jmfrank63) <jmfrank63@gmail.com>
+Shane Steinert-Threlkeld (@shanest) <ssshanest@gmail.com>
 
 Note: (@user) means a github user name.

--- a/jedi/api/environment.py
+++ b/jedi/api/environment.py
@@ -19,6 +19,7 @@ _VersionInfo = namedtuple('VersionInfo', 'major minor micro')
 
 _SUPPORTED_PYTHONS = ['3.8', '3.7', '3.6', '3.5', '3.4', '2.7']
 _SAFE_PATHS = ['/usr/bin', '/usr/local/bin']
+_CONDA_VAR = 'CONDA_PREFIX'
 _CURRENT_VERSION = '%s.%s' % (sys.version_info.major, sys.version_info.minor)
 
 
@@ -189,6 +190,10 @@ def get_default_environment():
     if virtual_env is not None:
         return virtual_env
 
+    conda_env = _get_virtual_env_from_var(_CONDA_VAR)
+    if conda_env is not None:
+        return conda_env
+
     return _try_get_same_env()
 
 
@@ -279,7 +284,7 @@ def find_virtualenvs(paths=None, **kwargs):
             yield virtual_env
             _used_paths.add(virtual_env.path)
 
-        conda_env = _get_virtual_env_from_var('CONDA_PREFIX')
+        conda_env = _get_virtual_env_from_var(_CONDA_VAR)
         if conda_env is not None:
             yield conda_env
             _used_paths.add(conda_env.path)

--- a/jedi/api/environment.py
+++ b/jedi/api/environment.py
@@ -179,7 +179,8 @@ def _calculate_sha256_for_file(path):
 
 def get_default_environment():
     """
-    Tries to return an active Virtualenv. If there is no VIRTUAL_ENV variable
+    Tries to return an active Virtualenv or conda environment.
+    If there is no VIRTUAL_ENV variable or no CONDA_PREFIX variable set
     set it will return the latest Python version installed on the system. This
     makes it possible to use as many new Python features as possible when using
     autocompletion and other functionality.

--- a/jedi/api/environment.py
+++ b/jedi/api/environment.py
@@ -239,7 +239,7 @@ def _try_get_same_env():
 
 
 def get_cached_default_environment():
-    var = os.environ.get('VIRTUAL_ENV')
+    var = os.environ.get('VIRTUAL_ENV') or os.environ.get(_CONDA_VAR)
     environment = _get_cached_default_environment()
 
     # Under macOS in some cases - notably when using Pipenv - the

--- a/jedi/api/environment.py
+++ b/jedi/api/environment.py
@@ -147,13 +147,13 @@ class InterpreterEnvironment(_SameEnvironmentMixin, _BaseEnvironment):
         return sys.path
 
 
-def _get_virtual_env_from_var():
+def _get_virtual_env_from_var(env_var='VIRTUAL_ENV'):
     """Get virtualenv environment from VIRTUAL_ENV environment variable.
 
     It uses `safe=False` with ``create_environment``, because the environment
     variable is considered to be safe / controlled by the user solely.
     """
-    var = os.environ.get('VIRTUAL_ENV')
+    var = os.environ.get(env_var)
     if var:
         # Under macOS in some cases - notably when using Pipenv - the
         # sys.prefix of the virtualenv is /path/to/env/bin/.. instead of
@@ -256,7 +256,8 @@ def find_virtualenvs(paths=None, **kwargs):
     :param paths: A list of paths in your file system to be scanned for
         Virtualenvs. It will search in these paths and potentially execute the
         Python binaries. Also the VIRTUAL_ENV variable will be checked if it
-        contains a valid Virtualenv.
+        contains a valid Virtualenv.  And CONDA_PREFIX will be checked to see
+        if it contains a valid conda environment.
     :param safe: Default True. In case this is False, it will allow this
         function to execute potential `python` environments. An attacker might
         be able to drop an executable in a path this function is searching by
@@ -277,6 +278,11 @@ def find_virtualenvs(paths=None, **kwargs):
         if virtual_env is not None:
             yield virtual_env
             _used_paths.add(virtual_env.path)
+
+        conda_env = _get_virtual_env_from_var('CONDA_PREFIX')
+        if conda_env is not None:
+            yield conda_env
+            _used_paths.add(conda_env.path)
 
         for directory in paths:
             if not os.path.isdir(directory):


### PR DESCRIPTION
As we discussed in `jedi-vim` issue 907 (https://github.com/davidhalter/jedi-vim/issues/907), this is a PR that makes `get_default_environment` use an activated conda environment if it doesn't find a virtualenv.  And then it still defaults to system python if it finds neither.  (I also made `find_virtualenvs` looks for conda environments.) 

I've installed a version of `jedi-vim` that points to this version of `jedi`, and it works well for me :).