### PR TITLE
Fix: no longer shows folders recursively to root

### DIFF
--- a/jedi/api/project.py
+++ b/jedi/api/project.py
@@ -110,7 +110,10 @@ class Project(object):
                 suffixed += discover_buildout_paths(inference_state, inference_state.script_path)
 
                 if add_parent_paths:
-                    traversed = list(traverse_parents(inference_state.script_path))
+                    traversed = list(traverse_parents(
+                        inference_state.script_path,
+                        root=self._path,
+                    ))
 
                     # AFAIK some libraries have imports like `foo.foo.bar`, which
                     # leads to the conclusion to by default prefer longer paths

--- a/jedi/api/project.py
+++ b/jedi/api/project.py
@@ -110,7 +110,17 @@ class Project(object):
                 suffixed += discover_buildout_paths(inference_state, inference_state.script_path)
 
                 if add_parent_paths:
-                    traversed = list(traverse_parents(inference_state.script_path))
+                    # Collect directories in upward search until we:
+                    #   1. Hit any directory without an __init__.py, AND
+                    #   2. Are above self._path.
+                    traversed = []
+                    no_init = False
+                    for parent_path in traverse_parents(inference_state.script_path):
+                        if not os.path.isfile(os.path.join(parent_path, "__init__.py")):
+                            no_init = True
+                        if no_init and not parent_path.startswith(self._path):
+                            break
+                        traversed.append(parent_path)
 
                     # AFAIK some libraries have imports like `foo.foo.bar`, which
                     # leads to the conclusion to by default prefer longer paths

--- a/jedi/api/project.py
+++ b/jedi/api/project.py
@@ -110,16 +110,15 @@ class Project(object):
                 suffixed += discover_buildout_paths(inference_state, inference_state.script_path)
 
                 if add_parent_paths:
-                    # Collect directories in upward search until we:
-                    #   1. Hit any directory without an __init__.py, AND
-                    #   2. Are above self._path.
+                    # Collect directories in upward search by:
+                    #   1. Skipping directories with __init__.py
+                    #   2. Stopping immediately when above self._path
                     traversed = []
-                    no_init = False
                     for parent_path in traverse_parents(inference_state.script_path):
-                        if not os.path.isfile(os.path.join(parent_path, "__init__.py")):
-                            no_init = True
-                        if no_init and not parent_path.startswith(self._path):
+                        if not parent_path.startswith(self._path):
                             break
+                        if os.path.isfile(os.path.join(parent_path, "__init__.py")):
+                            continue
                         traversed.append(parent_path)
 
                     # AFAIK some libraries have imports like `foo.foo.bar`, which

--- a/jedi/api/project.py
+++ b/jedi/api/project.py
@@ -110,10 +110,7 @@ class Project(object):
                 suffixed += discover_buildout_paths(inference_state, inference_state.script_path)
 
                 if add_parent_paths:
-                    traversed = list(traverse_parents(
-                        inference_state.script_path,
-                        root=self._path,
-                    ))
+                    traversed = list(traverse_parents(inference_state.script_path))
 
                     # AFAIK some libraries have imports like `foo.foo.bar`, which
                     # leads to the conclusion to by default prefer longer paths

--- a/jedi/common/utils.py
+++ b/jedi/common/utils.py
@@ -2,15 +2,31 @@ import os
 from contextlib import contextmanager
 
 
-def traverse_parents(path, include_current=False):
+def traverse_parents(path, root=None, include_current=False):
+    """Iterate directories from a path to search root
+
+    :path: the path of the script/directory to check.
+    :root: the root of the upward search. Assumes the system root if root is
+            None.
+    :include_current: includes the current file / directory.
+
+    If the root path is not a substring of the provided path, assume the root
+    search path as well.
+    """
     if not include_current:
         path = os.path.dirname(path)
 
     previous = None
-    while previous != path:
-        yield path
-        previous = path
-        path = os.path.dirname(path)
+    if root is None or not path.startswith(root):
+        while previous != path:
+            yield path
+            previous = path
+            path = os.path.dirname(path)
+    else:
+        while previous != root:
+            yield path
+            previous = path
+            path = os.path.dirname(path)
 
 
 @contextmanager

--- a/jedi/common/utils.py
+++ b/jedi/common/utils.py
@@ -2,31 +2,15 @@ import os
 from contextlib import contextmanager
 
 
-def traverse_parents(path, root=None, include_current=False):
-    """Iterate directories from a path to search root
-
-    :path: the path of the script/directory to check.
-    :root: the root of the upward search. Assumes the system root if root is
-            None.
-    :include_current: includes the current file / directory.
-
-    If the root path is not a substring of the provided path, assume the root
-    search path as well.
-    """
+def traverse_parents(path, include_current=False):
     if not include_current:
         path = os.path.dirname(path)
 
     previous = None
-    if root is None or not path.startswith(root):
-        while previous != path:
-            yield path
-            previous = path
-            path = os.path.dirname(path)
-    else:
-        while previous != root:
-            yield path
-            previous = path
-            path = os.path.dirname(path)
+    while previous != path:
+        yield path
+        previous = path
+        path = os.path.dirname(path)
 
 
 @contextmanager


### PR DESCRIPTION
Fixes: https://github.com/davidhalter/jedi/issues/1446

In the previous implementation, Jedi would's traverse_parents function
traversed parent directories to the system root every time. This would
inadvertently add every folder to the system root every time. Obviously,
this is not the behavior desired for the import system.

This pull request provides a new argument to the traverse_parents
function, "root", which represents the root parent for the search. This
argument defaults to None, thereby preserving the existing behavior of
the function.

I chose to duplicate some code for performance reasons. Since I'm trying
to avoid too much path manipulation magic, we do:

* a search to a valid specified root, OR
* a simple upward search until hitting the system root when there is no
valid root specified.