### PR TITLE
WIP: Improve Usage of Type Annotations (Dynamic and Static) in Interpreter Context

### DIFF
--- a/jedi/inference/compiled/access.py
+++ b/jedi/inference/compiled/access.py
@@ -531,7 +531,8 @@ class DirectObjectAccess(object):
 
     def get_return_annotation(self):
         try:
-            o = self._obj.__annotations__.get('return')
+            import typing
+            o = typing.get_type_hints(self._obj).get('return')
         except AttributeError:
             return None
 

--- a/jedi/inference/compiled/access.py
+++ b/jedi/inference/compiled/access.py
@@ -533,6 +533,15 @@ class DirectObjectAccess(object):
         try:
             import typing
             o = typing.get_type_hints(self._obj).get('return')
+            return self._create_access_path(o)
+        except ImportError:
+            # Old behaviour
+            pass
+        except AttributeError:
+            return None
+
+        try:
+            o = self._obj.__annotations__.get('return')
         except AttributeError:
             return None
 

--- a/jedi/inference/compiled/value.py
+++ b/jedi/inference/compiled/value.py
@@ -49,7 +49,6 @@ class CompiledObject(Value):
     def py__call__(self, arguments):
         return_annotation = self.access_handle.get_return_annotation()
         if return_annotation is not None:
-            # TODO the return annotation may also be a string.
             return create_from_access_path(
                 self.inference_state,
                 return_annotation


### PR DESCRIPTION
This is a follow up to https://github.com/davidhalter/jedi/issues/1458.

General goals/ideas:
- Interpreter should use `__annotations__` of the object it is trying to auto complete on (mostly functions for now).
  - This should work already, 1c62ecb extends this so [PEP 563](https://www.python.org/dev/peps/pep-0563) annotations should work too. There are still some [pitfalls](https://www.python.org/dev/peps/pep-0563/#runtime-annotation-resolution-and-type-checking), but this should be strictly better than the current implementation 
- If a `-stub` package is available there should be the option for the completer to use this instead of what the object provides.
  - First this should work for any typical stub package that is installed in the used virtualenv and for `.pyi` files in the actual module.
  - There are two extremes here that I have actually encountered and have some interest in covering. I think the latter is better and is also useful in general.
     - An RPC implementation that wants to lie about the annotations of the object (based on the annotations of the remote object)
     - the possibility to force that all completion for a module happens based on local stub files, which would be applied based on the bridged fake type and not the true type (RPC object) of the object so no RPC calls need to happen for completion.
 
Current Todos:
- [x] Handle PEP 563 annotations
- [ ] Test for PEP 563 annotations
- [ ] Decide on general implementation for  annotations in `.pyi` files next to `.py` files
- [ ] Decide on general implementation for  annotations in separate `-stub` package

Questions:
I do not have a good high level concept of the jedi architecture yet. The first issue is where the stub based inference happens for Script contexts, how much of this can be used for Interpreter contexts and if that requires refactoring to move code out of the interpreter context so it can be shared.