### PR TITLE
TypedDict completions: tests added

### DIFF
--- a/jedi/inference/gradual/typing.py
+++ b/jedi/inference/gradual/typing.py
@@ -400,7 +400,7 @@ class TypedDict(LazyValueWrapper):
 
     def get_key_values(self):
         filtered_values = itertools.chain.from_iterable((
-            f.values(from_instance=True)
+            f.values()
             for f in self._definition_class.get_filters(is_instance=True)
         ))
         return ValueSet({

--- a/test/completion/pep0484_typing.py
+++ b/test/completion/pep0484_typing.py
@@ -569,9 +569,7 @@ class Bar(Foo):
 
     #? int()
     another_variable
-    #? str()
-    foo
-    #? int()
+    #?
     an_int
 
 def typed_dict_test_foo(arg: Bar):

--- a/test/completion/pep0484_typing.py
+++ b/test/completion/pep0484_typing.py
@@ -510,7 +510,6 @@ class Foo(typing.TypedDict):
     foo: str
     bar: typing.List[float]
     an_int: int
-    foo
     #! ['foo: str']
     foo
     #? str()
@@ -525,8 +524,10 @@ def typed_dict_test_foo(arg: Foo):
 
     #? str()
     a_string
-    #? [float()]
-    a_list_of_strings
+    #? list()
+    a_list_of_floats
+    #? float()
+    a_list_of_floats[0]
     #? int()
     an_int
 
@@ -558,7 +559,41 @@ Foo.set
 #? ['setdefault']
 d.setdefaul
 
-#? 5 ["'foo'"]
+#? 5 ["'foo"]
 d['fo']
 #? 5 ['"bar"']
 d["bar"]
+
+class Bar(Foo):
+    another_variable: int
+
+    #? int()
+    another_variable
+    #? str()
+    foo
+    #? int()
+    an_int
+
+def typed_dict_test_foo(arg: Bar):
+    a_string = arg['foo']
+    a_list_of_floats = arg['bar']
+    an_int = arg['an_int']
+    another_variable = arg['another_variable']
+
+    #? str()
+    a_string
+    #? list()
+    a_list_of_floats
+    #? float()
+    a_list_of_floats[0]
+    #? int()
+    an_int
+    #? int()
+    another_variable
+
+    #? ['isupper']
+    a_string.isuppe
+    #? ['pop']
+    a_list_of_floats.po
+    #? ['as_integer_ratio']
+    an_int.as_integer_rati

--- a/test/completion/pep0484_typing.py
+++ b/test/completion/pep0484_typing.py
@@ -509,11 +509,33 @@ dynamic_annotation('')
 class Foo(typing.TypedDict):
     foo: str
     bar: typing.List[float]
+    an_int: int
     foo
     #! ['foo: str']
     foo
     #? str()
     foo
+    #? int()
+    an_int
+
+def typed_dict_test_foo(arg: Foo):
+    a_string = arg['foo']
+    a_list_of_floats = arg['bar']
+    an_int = arg['an_int']
+
+    #? str()
+    a_string
+    #? [float()]
+    a_list_of_strings
+    #? int()
+    an_int
+
+    #? ['isupper']
+    a_string.isuppe
+    #? ['pop']
+    a_list_of_floats.po
+    #? ['as_integer_ratio']
+    an_int.as_integer_rati
 
 #! ['class Foo']
 d: Foo


### PR DESCRIPTION
Continues the conversation in this issue: https://github.com/davidhalter/jedi/issues/1478

Note: many tests are failing at present, but not the ones I've added. Notably, one of the tests for actually completing TypedDict keyword parameters that includes quotes is failing weirdly. This tells me there may be an improperly-handled edge case for key completion somewhere. @davidhalter do you have any ideas about where this could be coming from?

```traceback
case = <IntegrationTestCase: /home/sroeca/src/Personal/jedi/test/completion/pep0484_typing.py:561 "d['fo']">, actual = {"'foo"}, desired = {"'foo'"}

    def assert_case_equal(case, actual, desired):
        """
        Assert ``actual == desired`` with formatted message.

        This is not needed for typical pytest use case, but as we need
        ``--assert=plain`` (see ../pytest.ini) to workaround some issue
        due to pytest magic, let's format the message by hand.
        """
>       assert actual == desired, """
    Test %r failed.
    actual  = %s
    desired = %s
    """ % (case, actual, desired)
E       AssertionError:
E         Test <IntegrationTestCase: /home/sroeca/src/Personal/jedi/test/completion/pep0484_typing.py:561 "d['fo']"> failed.
E         actual  = {"'foo"}
E         desired = {"'foo'"}
E
E       assert {"'foo"} == {"'foo'"}
E         Extra items in the left set:
E         "'foo"
E         Extra items in the right set:
E         "'foo'"
E         Use -v to get the full diff
```