### PR TITLE
Fix some small issues with sith show_locations

### DIFF
--- a/sith.py
+++ b/sith.py
@@ -151,7 +151,7 @@ class TestCase(object):
         # Three lines ought to be enough
         lower = lineno - show if lineno - show > 0 else 0
         prefix = '  |'
-        for i, line in enumerate(self.script._source.split('\n')[lower:lineno]):
+        for i, line in enumerate(self.script._code.split('\n')[lower:lineno]):
             print(prefix, lower + i + 1, line)
         print(prefix, '   ', ' ' * (column + len(str(lineno))), '^')
 

--- a/sith.py
+++ b/sith.py
@@ -153,7 +153,7 @@ class TestCase(object):
         prefix = '  |'
         for i, line in enumerate(self.script._code.split('\n')[lower:lineno]):
             print(prefix, lower + i + 1, line)
-        print(prefix, '   ', ' ' * (column + len(str(lineno))), '^')
+        print(prefix, ' ' * (column + len(str(lineno))), '^')
 
     def show_operation(self):
         print("%s:\n" % self.operation.capitalize())


### PR DESCRIPTION
- updates sith to use `Script._code` over `Script._source` which doesn't seem to exist (maybe removed in 16b463a64664989ba2aa276486f0e5e08e775685?)
- removes what appears to be a duplicate prefix entry on the line which shows what the column position is