### PR TITLE
Add venv to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ jedi.egg-info/
 record.json
 /.cache/
 /.pytest_cache
+/venv/


### PR DESCRIPTION
I would like to contribute to Jedi, but I noticed that `venv`'s were not gitignored.  When installing all the `requirements.txt`'s, I want to isolate them to a `venv`.  Hence, this brief PR.