### PR TITLE
Remove the word 'class' from annotation_string

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -55,5 +55,6 @@ Max Woerner Chase (@mwchase) <max.chase@gmail.com>
 Johannes Maria Frank (@jmfrank63) <jmfrank63@gmail.com>
 Shane Steinert-Threlkeld (@shanest) <ssshanest@gmail.com>
 Tim Gates (@timgates42) <tim.gates@iress.com>
+Lior Goldberg (@goldberglior)
 
 Note: (@user) means a github user name.

--- a/jedi/inference/compiled/access.py
+++ b/jedi/inference/compiled/access.py
@@ -484,6 +484,11 @@ class DirectObjectAccess(object):
     def needs_type_completions(self):
         return inspect.isclass(self._obj) and self._obj != type
 
+    def _annotation_to_str(self, annotation):
+        if isinstance(annotation, type):
+            return str(annotation.__name__)
+        return str(annotation)
+
     def get_signature_params(self):
         return [
             SignatureParam(
@@ -493,7 +498,7 @@ class DirectObjectAccess(object):
                 default_string=repr(p.default),
                 has_annotation=p.annotation is not p.empty,
                 annotation=self._create_access_path(p.annotation),
-                annotation_string=str(p.annotation),
+                annotation_string=self._annotation_to_str(p.annotation),
                 kind_name=str(p.kind)
             ) for p in self._get_signature().parameters.values()
         ]

--- a/test/test_api/test_interpreter.py
+++ b/test/test_api/test_interpreter.py
@@ -342,7 +342,7 @@ def test_completion_params():
 
 @pytest.mark.skipif('py_version < 33', reason='inspect.signature was created in 3.3.')
 def test_completion_param_annotations():
-    # Need to define this function not directly in Python. Otherwise Jedi is to
+    # Need to define this function not directly in Python. Otherwise Jedi is too
     # clever and uses the Python code instead of the signature object.
     code = 'def foo(a: 1, b: str, c: int = 1.0) -> bytes: pass'
     exec_(code, locals())
@@ -353,6 +353,10 @@ def test_completion_param_annotations():
     assert a.infer() == []
     assert [d.name for d in b.infer()] == ['str']
     assert {d.name for d in c.infer()} == {'int', 'float'}
+
+    assert a.description == 'param a: 1'
+    assert b.description == 'param b: str'
+    assert c.description == 'param c: int=1.0'
 
     d, = jedi.Interpreter('foo()', [locals()]).infer()
     assert d.name == 'bytes'


### PR DESCRIPTION
Currently, 'foo(x: int)' results with annotation_string="<class 'int'>".
Change this to 'int'.