### PR TITLE
Add partialmethod, fixes #1519

### DIFF
--- a/test/completion/stdlib.py
+++ b/test/completion/stdlib.py
@@ -158,6 +158,23 @@ tup[0]
 #? float()
 tup[1]
 
+class X:
+    def function(self, a, b):
+        return a, b
+    a = functools.partialmethod(function, 0)
+    kw = functools.partialmethod(function, b=1.0)
+
+#? int()
+X().a('')[0]
+#? str()
+X().a('')[1]
+
+tup = X().kw(1)
+#? int()
+tup[0]
+#? float()
+tup[1]
+
 def my_decorator(f):
     @functools.wraps(f)
     def wrapper(*args, **kwds):

--- a/test/completion/stdlib.py
+++ b/test/completion/stdlib.py
@@ -170,11 +170,22 @@ X().a('')[0]
 X().a('')[1]
 
 #? int()
+X.a('')[0]
+#? str()
+X.a('')[1]
+
+#? int()
 X.a(X(), '')[0]
 #? str()
 X.a(X(), '')[1]
 
 tup = X().kw(1)
+#? int()
+tup[0]
+#? float()
+tup[1]
+
+tup = X.kw(1)
 #? int()
 tup[0]
 #? float()

--- a/test/completion/stdlib.py
+++ b/test/completion/stdlib.py
@@ -169,11 +169,23 @@ X().a('')[0]
 #? str()
 X().a('')[1]
 
+#? int()
+X.a(X(), '')[0]
+#? str()
+X.a(X(), '')[1]
+
 tup = X().kw(1)
 #? int()
 tup[0]
 #? float()
 tup[1]
+
+tup = X.kw(X(), 1)
+#? int()
+tup[0]
+#? float()
+tup[1]
+
 
 def my_decorator(f):
     @functools.wraps(f)

--- a/test/test_inference/test_signature.py
+++ b/test/test_inference/test_signature.py
@@ -100,6 +100,8 @@ class X:
         (partialmethod_code + 'X().b(', 'func(b, c)'),
         (partialmethod_code + 'X().c(', 'func(b)'),
         (partialmethod_code + 'X().d(', None),
+        (partialmethod_code + 'X.c(', 'func(b)'),
+        (partialmethod_code + 'X.d(', None),
     ]
 )
 def test_tree_signature(Script, environment, code, expected):

--- a/test/test_inference/test_signature.py
+++ b/test/test_inference/test_signature.py
@@ -65,6 +65,19 @@ d = functools.partial()
 '''
 
 
+partialmethod_code = '''
+import functools
+
+class X:
+    def func(self, a, b, c):
+        pass
+    a = functools.partialmethod(func)
+    b = functools.partialmethod(func, 1)
+    c = functools.partialmethod(func, 1, c=2)
+    d = functools.partialmethod()
+'''
+
+
 @pytest.mark.parametrize(
     'code, expected', [
         ('def f(a, * args, x): pass\n f(', 'f(a, *args, x)'),
@@ -82,6 +95,11 @@ d = functools.partial()
         (partial_code + 'b(', 'func(b, c)'),
         (partial_code + 'c(', 'func(b)'),
         (partial_code + 'd(', None),
+
+        (partialmethod_code + 'X().a(', 'func(a, b, c)'),
+        (partialmethod_code + 'X().b(', 'func(b, c)'),
+        (partialmethod_code + 'X().c(', 'func(b)'),
+        (partialmethod_code + 'X().d(', None),
     ]
 )
 def test_tree_signature(Script, environment, code, expected):


### PR DESCRIPTION
Returns correct method signature but test/completion/stdlib.py fails

I have added the test output below. The second kwarg test seems to pass, but the others don't. Since the first test fails because it gets what I assume is the value that's expected for the next test, I suspect that the issue is that I just increase the `arg_count` in L541.

While I'm not sure what method VSCode is using for getting the signature, using my fix I also get `self` included in the signature (a.k.a. parameter hints), which is not the case for normal methods.


```
> pytest test/test_integration.py -k stdlib
```
```
============================= test session starts ==============================
platform darwin -- Python 3.8.2, pytest-5.3.5, py-1.8.1, pluggy-0.13.1
rootdir: /Users/Daniel/projects/ffe4/jedi, inifile: pytest.ini
collected 1841 items / 1755 deselected / 86 selected

test/test_integration.py ....................................FFF........ [ 54%]
.......................................                                  [100%]

=================================== FAILURES ===================================
_________________________ test_completion[stdlib:167] __________________________

case = <IntegrationTestCase: /Users/Daniel/projects/ffe4/jedi/test/completion/stdlib.py:167 "X().a('')[0]">
monkeypatch = <_pytest.monkeypatch.MonkeyPatch object at 0x1072b7d90>
environment = <Environment: 3.8.2 in /Library/Frameworks/Python.framework/Versions/3.8>
has_typing = True

    def test_completion(case, monkeypatch, environment, has_typing):
        skip_reason = case.get_skip_reason(environment)
        if skip_reason is not None:
            pytest.skip(skip_reason)
    
        if 'pep0484_typing' in case.path and sys.version_info[0] == 2:
            pytest.skip('ditch python 2 finally')
    
        _CONTAINS_TYPING = ('pep0484_typing', 'pep0484_comments', 'pep0526_variables')
        if not has_typing and any(x in case.path for x in _CONTAINS_TYPING):
            pytest.skip('Needs the typing module installed to run this test.')
        repo_root = helpers.root_dir
        monkeypatch.chdir(os.path.join(repo_root, 'jedi'))
>       case.run(assert_case_equal, environment)

../test/test_integration.py:48: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
../test/run.py:215: in run
    return testers[self.test_type](compare_cb, environment)
../test/run.py:257: in run_inference
    return compare_cb(self, is_str, should)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

case = <IntegrationTestCase: /Users/Daniel/projects/ffe4/jedi/test/completion/stdlib.py:167 "X().a('')[0]">
actual = {'builtins:instance str()'}, desired = {'builtins:instance int()'}

    def assert_case_equal(case, actual, desired):
        """
        Assert ``actual == desired`` with formatted message.
    
        This is not needed for typical pytest use case, but as we need
        ``--assert=plain`` (see ../pytest.ini) to workaround some issue
        due to pytest magic, let's format the message by hand.
        """
>       assert actual == desired, """
    Test %r failed.
    actual  = %s
    desired = %s
    """ % (case, actual, desired)
E       AssertionError: 
E         Test <IntegrationTestCase: /Users/Daniel/projects/ffe4/jedi/test/completion/stdlib.py:167 "X().a('')[0]"> failed.
E         actual  = {'builtins:instance str()'}
E         desired = {'builtins:instance int()'}
E         
E       assert {'builtins:instance str()'} == {'builtins:instance int()'}
E         Extra items in the left set:
E         'builtins:instance str()'
E         Extra items in the right set:
E         'builtins:instance int()'
E         Use -v to get the full diff

../test/test_integration.py:17: AssertionError
_________________________ test_completion[stdlib:169] __________________________

case = <IntegrationTestCase: /Users/Daniel/projects/ffe4/jedi/test/completion/stdlib.py:169 "X().a('')[1]">
monkeypatch = <_pytest.monkeypatch.MonkeyPatch object at 0x1072d6ca0>
environment = <Environment: 3.8.2 in /Library/Frameworks/Python.framework/Versions/3.8>
has_typing = True

    def test_completion(case, monkeypatch, environment, has_typing):
        skip_reason = case.get_skip_reason(environment)
        if skip_reason is not None:
            pytest.skip(skip_reason)
    
        if 'pep0484_typing' in case.path and sys.version_info[0] == 2:
            pytest.skip('ditch python 2 finally')
    
        _CONTAINS_TYPING = ('pep0484_typing', 'pep0484_comments', 'pep0526_variables')
        if not has_typing and any(x in case.path for x in _CONTAINS_TYPING):
            pytest.skip('Needs the typing module installed to run this test.')
        repo_root = helpers.root_dir
        monkeypatch.chdir(os.path.join(repo_root, 'jedi'))
>       case.run(assert_case_equal, environment)

../test/test_integration.py:48: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
../test/run.py:215: in run
    return testers[self.test_type](compare_cb, environment)
../test/run.py:257: in run_inference
    return compare_cb(self, is_str, should)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

case = <IntegrationTestCase: /Users/Daniel/projects/ffe4/jedi/test/completion/stdlib.py:169 "X().a('')[1]">
actual = set(), desired = {'builtins:instance str()'}

    def assert_case_equal(case, actual, desired):
        """
        Assert ``actual == desired`` with formatted message.
    
        This is not needed for typical pytest use case, but as we need
        ``--assert=plain`` (see ../pytest.ini) to workaround some issue
        due to pytest magic, let's format the message by hand.
        """
>       assert actual == desired, """
    Test %r failed.
    actual  = %s
    desired = %s
    """ % (case, actual, desired)
E       AssertionError: 
E         Test <IntegrationTestCase: /Users/Daniel/projects/ffe4/jedi/test/completion/stdlib.py:169 "X().a('')[1]"> failed.
E         actual  = set()
E         desired = {'builtins:instance str()'}
E         
E       assert set() == {'builtins:instance str()'}
E         Extra items in the right set:
E         'builtins:instance str()'
E         Use -v to get the full diff

../test/test_integration.py:17: AssertionError
_________________________ test_completion[stdlib:173] __________________________

case = <IntegrationTestCase: /Users/Daniel/projects/ffe4/jedi/test/completion/stdlib.py:173 'tup[0]'>
monkeypatch = <_pytest.monkeypatch.MonkeyPatch object at 0x106c8b070>
environment = <Environment: 3.8.2 in /Library/Frameworks/Python.framework/Versions/3.8>
has_typing = True

    def test_completion(case, monkeypatch, environment, has_typing):
        skip_reason = case.get_skip_reason(environment)
        if skip_reason is not None:
            pytest.skip(skip_reason)
    
        if 'pep0484_typing' in case.path and sys.version_info[0] == 2:
            pytest.skip('ditch python 2 finally')
    
        _CONTAINS_TYPING = ('pep0484_typing', 'pep0484_comments', 'pep0526_variables')
        if not has_typing and any(x in case.path for x in _CONTAINS_TYPING):
            pytest.skip('Needs the typing module installed to run this test.')
        repo_root = helpers.root_dir
        monkeypatch.chdir(os.path.join(repo_root, 'jedi'))
>       case.run(assert_case_equal, environment)

../test/test_integration.py:48: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
../test/run.py:215: in run
    return testers[self.test_type](compare_cb, environment)
../test/run.py:257: in run_inference
    return compare_cb(self, is_str, should)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

case = <IntegrationTestCase: /Users/Daniel/projects/ffe4/jedi/test/completion/stdlib.py:173 'tup[0]'>
actual = set(), desired = {'builtins:instance int()'}

    def assert_case_equal(case, actual, desired):
        """
        Assert ``actual == desired`` with formatted message.
    
        This is not needed for typical pytest use case, but as we need
        ``--assert=plain`` (see ../pytest.ini) to workaround some issue
        due to pytest magic, let's format the message by hand.
        """
>       assert actual == desired, """
    Test %r failed.
    actual  = %s
    desired = %s
    """ % (case, actual, desired)
E       AssertionError: 
E         Test <IntegrationTestCase: /Users/Daniel/projects/ffe4/jedi/test/completion/stdlib.py:173 'tup[0]'> failed.
E         actual  = set()
E         desired = {'builtins:instance int()'}
E         
E       assert set() == {'builtins:instance int()'}
E         Extra items in the right set:
E         'builtins:instance int()'
E         Use -v to get the full diff

../test/test_integration.py:17: AssertionError
================ 3 failed, 83 passed, 1755 deselected in 5.95s =================
```