### PR TITLE
Replace the deprecated function "params" with "get_signatures()[...].params"

### DIFF
--- a/jedi/api/completion.py
+++ b/jedi/api/completion.py
@@ -33,7 +33,7 @@ class ParamNameWithEquals(ParamNameWrapper):
 def get_signature_param_names(signatures):
     # add named params
     for call_sig in signatures:
-        for p in call_sig.params:
+        for p in call_sig.get_signatures()[0].params:
             # Allow protected access, because it's a public API.
             if p._name.get_kind() in (Parameter.POSITIONAL_OR_KEYWORD,
                                       Parameter.KEYWORD_ONLY):


### PR DESCRIPTION
The function "get_signature_param_names" in jedi/jedi/api/completion.py uses the deprecated function "params" in BaseName class.
So, I replaced it with "get_signatures()[...].params" in BaseName class.