### PR TITLE
Inc difference limit in TestSetupReadline::test_import for py3.8

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -84,7 +84,7 @@ class TestSetupReadline(unittest.TestCase):
         }
         # There are quite a few differences, because both Windows and Linux
         # (posix and nt) librariesare included.
-        assert len(difference) < 20
+        assert len(difference) < 22
 
     def test_local_import(self):
         s = 'import test.test_utils'


### PR DESCRIPTION
Python 3.8 on Linux has 21 differences which exceed the current limit.
Increase it to 22.