### PR TITLE
Use explicit environment on subprocess

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -56,6 +56,7 @@ Code Contributors
 - Shane Steinert-Threlkeld (@shanest) <ssshanest@gmail.com>
 - Tim Gates (@timgates42) <tim.gates@iress.com>
 - Lior Goldberg (@goldberglior)
+- Ryan Clary (@mrclary)
 
 And a few more "anonymous" contributors.
 


### PR DESCRIPTION
Resolves #1540.

Use an explicit environment for subprocess to ensure that existing environment variables are not inherited. This ensures more reliable results.