### PR TITLE
Fix construction of nested generic tuple return types

### DIFF
--- a/jedi/inference/gradual/base.py
+++ b/jedi/inference/gradual/base.py
@@ -99,7 +99,7 @@ class DefineGenericBase(LazyValueWrapper):
         for generic_set in self.get_generics():
             values = NO_VALUES
             for generic in generic_set:
-                if isinstance(generic, (GenericClass, TypeVar)):
+                if isinstance(generic, (DefineGenericBase, TypeVar)):
                     result = generic.define_generics(type_var_dict)
                     values |= result
                     if result != ValueSet({generic}):

--- a/test/completion/pep0484_generic_mismatches.py
+++ b/test/completion/pep0484_generic_mismatches.py
@@ -206,40 +206,36 @@ for a in list_func_t_to_list_t(12):
     a
 
 
-# The following are all actually wrong, however we're mainly testing here that
-# we don't error when processing invalid values, rather than that we get the
-# right output.
-
 x0 = list_func_t_to_list_t(["abc"])[0]
-#? str()
+#?
 x0
 
 x2 = list_func_t_to_list_t([tpl])[0]
-#? tuple()
+#?
 x2
 
 x3 = list_func_t_to_list_t([tpl_typed])[0]
-#? tuple()
+#?
 x3
 
 x4 = list_func_t_to_list_t([collection])[0]
-#? dict()
+#?
 x4
 
 x5 = list_func_t_to_list_t([collection_typed])[0]
-#? dict()
+#?
 x5
 
 x6 = list_func_t_to_list_t([custom_generic])[0]
-#? CustomGeneric()
+#?
 x6
 
 x7 = list_func_t_to_list_t([plain_instance])[0]
-#? PlainClass()
+#?
 x7
 
 for a in list_func_t_to_list_t([12]):
-    #? int()
+    #?
     a
 
 

--- a/test/completion/pep0484_generic_parameters.py
+++ b/test/completion/pep0484_generic_parameters.py
@@ -6,6 +6,7 @@ from typing import (
     Iterable,
     List,
     Mapping,
+    Tuple,
     Type,
     TypeVar,
     Union,
@@ -57,6 +58,26 @@ x1
 for b in list_type_t_to_list_t(list_of_int_type):
     #? int()
     b
+
+
+# Test construction of nested generic tuple return parameters
+def list_t_to_list_tuple_t(the_list: List[T]) -> List[Tuple[T]]:
+    return [(x,) for x in the_list]
+
+
+x1t = list_t_to_list_tuple_t(list_of_ints)[0][0]
+#? int()
+x1t
+
+
+for c1 in list_t_to_list_tuple_t(list_of_ints):
+    #? int()
+    c1[0]
+
+
+for c2, in list_t_to_list_tuple_t(list_of_ints):
+    #? int()
+    c2
 
 
 def foo(x: T) -> T:

--- a/test/completion/pep0484_generic_parameters.py
+++ b/test/completion/pep0484_generic_parameters.py
@@ -80,11 +80,11 @@ for c2, in list_t_to_list_tuple_t(list_of_ints):
     c2
 
 
-def foo(x: T) -> T:
+def foo(x: int) -> int:
     return x
 
 
-list_of_funcs = [foo]  # type: List[Callable[[T], T]]
+list_of_funcs = [foo]  # type: List[Callable[[int], int]]
 
 def list_func_t_to_list_func_type_t(the_list: List[Callable[[T], T]]) -> List[Callable[[Type[T]], T]]:
     def adapt(func: Callable[[T], T]) -> Callable[[Type[T]], T]:

--- a/test/completion/pep0484_generic_parameters.py
+++ b/test/completion/pep0484_generic_parameters.py
@@ -80,6 +80,7 @@ for c2, in list_t_to_list_tuple_t(list_of_ints):
     c2
 
 
+# Test handling of nested callables
 def foo(x: int) -> int:
     return x
 
@@ -97,6 +98,21 @@ def list_func_t_to_list_func_type_t(the_list: List[Callable[[T], T]]) -> List[Ca
 for b in list_func_t_to_list_func_type_t(list_of_funcs):
     #? int()
     b(int)
+
+
+def bar(*a, **k) -> int:
+    return len(a) + len(k)
+
+
+list_of_funcs_2 = [bar]  # type: List[Callable[..., int]]
+
+def list_func_t_passthrough(the_list: List[Callable[..., T]]) -> List[Callable[..., T]]:
+    return the_list
+
+
+for b in list_func_t_passthrough(list_of_funcs_2):
+    #? int()
+    b(None, x="x")
 
 
 mapping_int_str = {42: 'a'}  # type: Dict[int, str]


### PR DESCRIPTION
Previously the construction of some return types missed populating the generic parameters when they were known.

Notably this overlooked tuples and callables, leading to incomplete information for signatures like the following:

``` python
def func(the_list: List[T]) -> List[Tuple[T]]:
    return [(x,) for x in the_list]

def list_func_t_passthrough(the_list: List[Callable[..., T]]) -> List[Callable[..., T]]:
    return the_list
```

This PR fixes both of these.

Fixing this also showed up a an issue where the concrete type parameter of the return value within a callable in the argument to the function currently being evaluated was not always detected correctly:

``` python
list_of_funcs_2 = [bar]  # type: List[Callable[..., int]]

for b in list_func_t_passthrough(list_of_funcs_2):
    #? int()
    b(None, x="x") 
```

This PR also fixes this issue.