### PR TITLE
Support accessing the py__class__ of a NewType

### DIFF
--- a/jedi/inference/gradual/typing.py
+++ b/jedi/inference/gradual/typing.py
@@ -413,6 +413,10 @@ class NewType(Value):
         self._type_value_set = type_value_set
         self.tree_node = tree_node
 
+    def py__class__(self):
+        c, = self._type_value_set.py__class__()
+        return c
+
     def py__call__(self, arguments):
         return self._type_value_set.execute_annotation()
 

--- a/test/completion/pep0484_typing.py
+++ b/test/completion/pep0484_typing.py
@@ -283,6 +283,18 @@ def testnewtype2(y):
     y
     #? []
     y.
+
+# The type of a NewType is equivalent to the type of its underlying type.
+MyInt = typing.NewType('MyInt', int)
+x = type(MyInt)
+#? type.mro
+x.mro
+
+PlainInt = int
+y = type(PlainInt)
+#? type.mro
+y.mro
+
 # python > 2.7
 
 class TestDefaultDict(typing.DefaultDict[str, int]):


### PR DESCRIPTION
The test here is a bit contrived, the actual place I found this was in using a `NewType` as a type within a `NamedTuple`. However due to https://github.com/davidhalter/jedi/issues/1560 that currently also fails for other reasons. This still feels useful to fix on its own though.