### PR TITLE
This fixes two issues with the caching on Windows / APPDATA

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -57,6 +57,7 @@ Code Contributors
 - Tim Gates (@timgates42) <tim.gates@iress.com>
 - Lior Goldberg (@goldberglior)
 - Ryan Clary (@mrclary)
+- Max Mäusezahl (@mmaeusezahl) <maxmaeusezahl@googlemail.com>
 
 And a few more "anonymous" contributors.
 

--- a/jedi/settings.py
+++ b/jedi/settings.py
@@ -69,8 +69,8 @@ Adds an opening bracket after a function for completions.
 # ----------------
 
 if platform.system().lower() == 'windows':
-    _cache_directory = os.path.join(os.getenv('APPDATA') or '~', 'Jedi',
-                                    'Jedi')
+    _cache_directory = os.path.join(os.getenv('LOCALAPPDATA') or 
+                                    os.path.expanduser('~'), 'Jedi', 'Jedi')
 elif platform.system().lower() == 'darwin':
     _cache_directory = os.path.join('~', 'Library', 'Caches', 'Jedi')
 else:
@@ -81,7 +81,7 @@ cache_directory = os.path.expanduser(_cache_directory)
 The path where the cache is stored.
 
 On Linux, this defaults to ``~/.cache/jedi/``, on OS X to
-``~/Library/Caches/Jedi/`` and on Windows to ``%APPDATA%\\Jedi\\Jedi\\``.
+``~/Library/Caches/Jedi/`` and on Windows to ``%LOCALAPPDATA%\\Jedi\\Jedi\\``.
 On Linux, if the environment variable ``$XDG_CACHE_HOME`` is set,
 ``$XDG_CACHE_HOME/jedi`` is used instead of the default one.
 """


### PR DESCRIPTION
The problem is that Jedi starts to fill the organizational storage space in %APPDATA% on Windows. In my case (with just minimal use) I have a 400MB Jedi folder that gets synced across our organizational network each time I log in (I am using Visual Studio Code which in turn uses Jedi).

### Fixes 

* The cache directory should really be %LOCALAPPDATA%
 * ~ is not a meaningful directory on Windows. It should really be
   os.path.expanduser('~'). To be honest it is probably always safe to
   assume that os.getenv('LOCALAPPDATA') executes to something sensible
   on any Windows system that hasn't been tampered with.

### Reasoning and a historical side note:

This issue was already reported once here: https://github.com/davidhalter/jedi/issues/926

It got then partially fixed, but only for parso in a different place (thinking of which, the second issure should probably also get ported there as well): https://github.com/davidhalter/parso/pull/1

Someone also temporarily fixed it in [pythonVSCode](https://github.com/DonJayamanne/pythonVSCode) (now maintained as [microsoft/vscode-python](https://github.com/microsoft/vscode-python)): https://github.com/DonJayamanne/pythonVSCode/pull/1035

But it got lost in https://github.com/microsoft/vscode-python/commit/20a7bd5ab03adac8bc63022a13049aaf748c64bc when Jedi was introduced as an external dependency much rather than pulling it in as external code.