### PR TITLE
Return 'class' as _PseudoTreeNameClass.type (fix #1578)

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -59,6 +59,7 @@ Code Contributors
 - Ryan Clary (@mrclary)
 - Max Mäusezahl (@mmaeusezahl) <maxmaeusezahl@googlemail.com>
 - Vladislav Serebrennikov (@endilll)
+- Andrii Kolomoiets (@muffinmad)
 
 And a few more "anonymous" contributors.
 

--- a/jedi/inference/gradual/base.py
+++ b/jedi/inference/gradual/base.py
@@ -306,6 +306,8 @@ class _PseudoTreeNameClass(Value):
     this class. Essentially this class makes it possible to goto that `Tuple`
     name, without affecting anything else negatively.
     """
+    api_type = u'class'
+
     def __init__(self, parent_context, tree_name):
         super(_PseudoTreeNameClass, self).__init__(
             parent_context.inference_state,

--- a/test/test_api/test_classes.py
+++ b/test/test_api/test_classes.py
@@ -599,3 +599,7 @@ def test_get_type_hint(Script, code, expected, skip_pre_python36):
     code = 'from typing import *\n' + code
     d, = Script(code).goto()
     assert d.get_type_hint() == expected
+
+
+def test_pseudotreenameclass_type(Script):
+    assert Script('from typing import Any\n').get_names()[0].type == 'class'

--- a/test/test_api/test_signatures.py
+++ b/test/test_api/test_signatures.py
@@ -13,7 +13,7 @@ _tuple_code = 'from typing import Tuple\ndef f(x: Tuple[int]): ...\nf'
         ('from typing import List\ndef f(x: List[int]): ...\nf', ['instance list'], True),
         ('from typing import List\ndef f(x: List[int]): ...\nf', ['class list'], False),
         (_tuple_code, ['instance tuple'], True),
-        (_tuple_code, ['Tuple: _SpecialForm = ...'], False),
+        (_tuple_code, ['class Tuple'], False),
         ('x=str\ndef f(p: x): ...\nx=int\nf', ['instance int'], True),
 
         ('def f(*args, **kwargs): ...\nf', [None, None], False),


### PR DESCRIPTION
See #1578 for details.