### PR TITLE
Support more Django model fields

### DIFF
--- a/jedi/plugins/django.py
+++ b/jedi/plugins/django.py
@@ -28,6 +28,7 @@ mapping = {
     'DurationField': ('datetime', 'timedelta'),
     'DateField': ('datetime', 'date'),
     'DateTimeField': ('datetime', 'datetime'),
+    'UUIDField': ('uuid', 'UUID'),
 }
 
 

--- a/jedi/plugins/django.py
+++ b/jedi/plugins/django.py
@@ -19,6 +19,7 @@ mapping = {
     'TextField': (None, 'str'),
     'EmailField': (None, 'str'),
     'GenericIPAddressField': (None, 'str'),
+    'URLField': (None, 'str'),
     'FloatField': (None, 'float'),
     'BinaryField': (None, 'bytes'),
     'BooleanField': (None, 'bool'),

--- a/jedi/plugins/django.py
+++ b/jedi/plugins/django.py
@@ -18,6 +18,7 @@ mapping = {
     'CharField': (None, 'str'),
     'TextField': (None, 'str'),
     'EmailField': (None, 'str'),
+    'GenericIPAddressField': (None, 'str'),
     'FloatField': (None, 'float'),
     'BinaryField': (None, 'bytes'),
     'BooleanField': (None, 'bool'),

--- a/jedi/plugins/django.py
+++ b/jedi/plugins/django.py
@@ -74,7 +74,7 @@ def _infer_field(cls, field_name):
 
         name = field_tree_instance.py__name__()
         is_many_to_many = name == 'ManyToManyField'
-        if name == 'ForeignKey' or is_many_to_many:
+        if name in ('ForeignKey', 'OneToOneField') or is_many_to_many:
             values = _get_foreign_key_values(cls, field_tree_instance)
             if is_many_to_many:
                 return ValueSet(filter(None, [

--- a/test/completion/django.py
+++ b/test/completion/django.py
@@ -27,6 +27,7 @@ class BusinessModel(models.Model):
     char_field = models.CharField()
     text_field = models.TextField()
     email_field = models.EmailField()
+    ip_address_field = models.GenericIPAddressField()
     float_field = models.FloatField()
     binary_field = models.BinaryField()
     boolean_field = models.BooleanField()
@@ -59,6 +60,8 @@ model_instance.char_field
 model_instance.text_field
 #? str()
 model_instance.email_field
+#? str()
+model_instance.ip_address_field
 #? float()
 model_instance.float_field
 #? bytes()

--- a/test/completion/django.py
+++ b/test/completion/django.py
@@ -28,6 +28,7 @@ class BusinessModel(models.Model):
     text_field = models.TextField()
     email_field = models.EmailField()
     ip_address_field = models.GenericIPAddressField()
+    url_field = models.URLField()
     float_field = models.FloatField()
     binary_field = models.BinaryField()
     boolean_field = models.BooleanField()
@@ -62,6 +63,8 @@ model_instance.text_field
 model_instance.email_field
 #? str()
 model_instance.ip_address_field
+#? str()
+model_instance.url_field
 #? float()
 model_instance.float_field
 #? bytes()

--- a/test/completion/django.py
+++ b/test/completion/django.py
@@ -1,5 +1,6 @@
 import datetime
 import decimal
+import uuid
 
 from django.db import models
 from django.contrib.auth.models import User
@@ -37,6 +38,7 @@ class BusinessModel(models.Model):
     duration_field = models.DurationField()
     date_field = models.DateField()
     date_time_field = models.DateTimeField()
+    uuid_field = models.UUIDField()
     tags_m2m = models.ManyToManyField(Tag)
 
     unidentifiable = NOT_FOUND
@@ -81,6 +83,8 @@ model_instance.duration_field
 model_instance.date_field
 #? datetime.datetime()
 model_instance.date_time_field
+#? uuid.UUID()
+model_instance.uuid_field
 
 #! ['category_fk = models.ForeignKey(Category)']
 model_instance.category_fk

--- a/test/completion/django.py
+++ b/test/completion/django.py
@@ -14,7 +14,13 @@ class Category(models.Model):
     category_name = models.CharField()
 
 
+class AttachedData(models.Model):
+    extra_data = models.TextField()
+
+
 class BusinessModel(models.Model):
+    attached_o2o = models.OneToOneField(AttachedData)
+
     category_fk = models.ForeignKey(Category)
     category_fk2 = models.ForeignKey('Category')
     category_fk3 = models.ForeignKey(1)
@@ -85,6 +91,15 @@ model_instance.date_field
 model_instance.date_time_field
 #? uuid.UUID()
 model_instance.uuid_field
+
+#! ['attached_o2o = models.OneToOneField(AttachedData)']
+model_instance.attached_o2o
+#! ['extra_data = models.TextField()']
+model_instance.attached_o2o.extra_data
+#? AttachedData()
+model_instance.attached_o2o
+#? str()
+model_instance.attached_o2o.extra_data
 
 #! ['category_fk = models.ForeignKey(Category)']
 model_instance.category_fk


### PR DESCRIPTION
Adds support for a few more Django model field types.

There are still a few field types left, but I think this is still useful.

At some point it might be worth exploring a better understanding of the inheritance chains (so that things like `EmailField` and `URLField` fall out of `CharField` without explicit listing), but just listing them works for now.