### PR TITLE
Import FileNotFoundError from jedi._compatibility

### DIFF
--- a/jedi/inference/references.py
+++ b/jedi/inference/references.py
@@ -3,6 +3,7 @@ import re
 
 from parso import python_bytes_to_unicode
 
+from jedi._compatibility import FileNotFoundError
 from jedi.debug import dbg
 from jedi.file_io import KnownContentFileIO
 from jedi.inference.imports import SubModuleName, load_module_from_path


### PR DESCRIPTION
Found this to be preventing calls to get_type_hint in some cases for Python 2.