### PR TITLE
Basic support for custom Django object managers

### DIFF
--- a/test/completion/django.py
+++ b/test/completion/django.py
@@ -49,6 +49,9 @@ class BusinessModel(models.Model):
 
     unidentifiable = NOT_FOUND
 
+    def method(self):
+        return 42
+
 # -----------------
 # Model attribute inference
 # -----------------
@@ -131,6 +134,11 @@ model_instance.tags_m2m.add
 model_instance.unidentifiable
 #! ['unidentifiable = NOT_FOUND']
 model_instance.unidentifiable
+
+#? int()
+model_instance.method()
+#! ['def method']
+model_instance.method
 
 # -----------------
 # Queries

--- a/test/completion/django.py
+++ b/test/completion/django.py
@@ -6,8 +6,17 @@ from django.db import models
 from django.contrib.auth.models import User
 
 
+class TagManager(models.Manager):
+    def specially_filtered_tags(self):
+        return self.all()
+
+
 class Tag(models.Model):
     tag_name = models.CharField()
+
+    objects = TagManager()
+
+    custom_objects = TagManager()
 
 
 class Category(models.Model):
@@ -154,6 +163,16 @@ model_instance.objects.get().char_field
 model_instance.objects.update(x='')
 #? BusinessModel()
 model_instance.objects.create()
+
+# -----------------
+# Custom object manager
+# -----------------
+
+#? TagManager()
+Tag.objects
+
+#? TagManager()
+Tag.custom_objects
 
 # -----------------
 # Inheritance


### PR DESCRIPTION
This fixes #1588.

For the moment this support is limited to just `Model.objects` replacements and does not use the custom manager for `ForeignKey` related managers.

Since the latter were previously not supported anyway, I think this is a reasonable limitation for now.