### PR TITLE
Explicitly handle `a not in b` operator comparison

### DIFF
--- a/jedi/inference/syntax_tree.py
+++ b/jedi/inference/syntax_tree.py
@@ -641,7 +641,7 @@ def _infer_comparison_part(inference_state, context, left, operator, right):
             _bool_to_value(inference_state, True),
             _bool_to_value(inference_state, False)
         ])
-    elif str_operator == 'in':
+    elif str_operator in ('in', 'not in'):
         return NO_VALUES
 
     def check(obj):

--- a/test/completion/precedence.py
+++ b/test/completion/precedence.py
@@ -100,6 +100,15 @@ else:
 #? str() int()
 a
 
+if 'X' not in 'Y':
+    b = 3
+else:
+    b = ''
+# For now don't really check for truth values. So in should return both
+# results.
+#? str() int()
+b
+
 # -----------------
 # for flow assignments
 # -----------------


### PR DESCRIPTION
This avoids a `KeyError` from operator_to_magic_method lookup for this case. Jedi probably could check for `__contains__` here, however as it doesn't do so for `in` checks I'm following that lead for now.

Fixes https://github.com/davidhalter/jedi/issues/1594.