### PR TITLE
Exclude more Linux constants in test_import

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -80,11 +80,13 @@ class TestSetupReadline(unittest.TestCase):
         difference = {
             x for x in difference
             if all(not x.startswith('from os import ' + s)
-                   for s in ['_', 'O_', 'EX_', 'MFD_', 'SF_', 'ST_'])
+                   for s in ['_', 'O_', 'EX_', 'MFD_', 'SF_', 'ST_',
+                             'CLD_', 'POSIX_SPAWN_', 'P_', 'RWF_',
+                             'SCHED_'])
         }
         # There are quite a few differences, because both Windows and Linux
         # (posix and nt) librariesare included.
-        assert len(difference) < 22
+        assert len(difference) < 15
 
     def test_local_import(self):
         s = 'import test.test_utils'


### PR DESCRIPTION
The list of differences have grown again in Python 3.9.  Instead of
increasing the allowed count let's filter out more Linux-specific
constants.  This probably makes it possible to reduce allowed
len(difference) too.

See #1608