### PR TITLE
Support for custom Django object managers

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/davidhalter/typeshed.git
 [submodule "jedi/third_party/django-stubs"]
 	path = jedi/third_party/django-stubs
-	url = https://github.com/typeddjango/django-stubs
+	url = https://github.com/davidhalter/django-stubs

--- a/jedi/api/__init__.py
+++ b/jedi/api/__init__.py
@@ -513,6 +513,8 @@ class Script(object):
         """
 
         def _references(include_builtins=True, scope='project'):
+            if scope not in ('project', 'file'):
+                raise ValueError('Only the scopes "file" and "project" are allowed')
             tree_name = self._module_node.get_name_of_position((line, column))
             if tree_name is None:
                 # Must be syntax

--- a/jedi/inference/base_value.py
+++ b/jedi/inference/base_value.py
@@ -174,6 +174,9 @@ class Value(HelperValueMixin):
     def is_class(self):
         return False
 
+    def is_class_mixin(self):
+        return False
+
     def is_instance(self):
         return False
 

--- a/jedi/inference/base_value.py
+++ b/jedi/inference/base_value.py
@@ -240,6 +240,9 @@ class Value(HelperValueMixin):
         debug.warning("No __get__ defined on %s", self)
         return ValueSet([self])
 
+    def py__get__on_class(self, calling_instance, instance, class_value):
+        return NotImplemented
+
     def get_qualified_names(self):
         # Returns Optional[Tuple[str, ...]]
         return None

--- a/jedi/inference/filters.py
+++ b/jedi/inference/filters.py
@@ -255,7 +255,7 @@ class _BuiltinMappedMethod(ValueWrapper):
 
     def py__call__(self, arguments):
         # TODO add TypeError if params are given/or not correct.
-        return self._method(self._value)
+        return self._method(self._value, arguments)
 
 
 class SpecialMethodFilter(DictFilter):
@@ -330,7 +330,7 @@ class _AttributeOverwriteMixin(object):
     def get_filters(self, *args, **kwargs):
         yield SpecialMethodFilter(self, self.overwritten_methods, self._wrapped_value)
 
-        for filter in self._wrapped_value.get_filters():
+        for filter in self._wrapped_value.get_filters(*args, **kwargs):
             yield filter
 
 

--- a/jedi/inference/gradual/base.py
+++ b/jedi/inference/gradual/base.py
@@ -200,6 +200,9 @@ class GenericClass(DefineGenericBaseClass, ClassMixin):
             return True
         return self._class_value.is_sub_class_of(class_value)
 
+    def with_generics(self, generics_tuple):
+        return self._class_value.with_generics(generics_tuple)
+
     def infer_type_vars(self, value_set):
         # Circular
         from jedi.inference.gradual.annotation import merge_pairwise_generics, merge_type_var_dicts
@@ -286,6 +289,9 @@ class _LazyGenericBaseClass(object):
                     # case just add it to the value set.
                     new |= ValueSet([type_var])
             yield new
+
+    def __repr__(self):
+        return '<%s: %s>' % (self.__class__.__name__, self._lazy_base_class)
 
 
 class _GenericInstanceWrapper(ValueWrapper):

--- a/jedi/inference/gradual/base.py
+++ b/jedi/inference/gradual/base.py
@@ -151,7 +151,7 @@ class DefineGenericBaseClass(LazyValueWrapper):
         )
 
 
-class GenericClass(ClassMixin, DefineGenericBaseClass):
+class GenericClass(DefineGenericBaseClass, ClassMixin):
     """
     A class that is defined with generics, might be something simple like:
 

--- a/jedi/inference/gradual/typing.py
+++ b/jedi/inference/gradual/typing.py
@@ -203,7 +203,7 @@ class _TypingClassMixin(ClassMixin):
         return ValueName(self, self._tree_name)
 
 
-class TypingClassWithGenerics(_TypingClassMixin, ProxyWithGenerics):
+class TypingClassWithGenerics(ProxyWithGenerics, _TypingClassMixin):
     def infer_type_vars(self, value_set):
         type_var_dict = {}
         annotation_generics = self.get_generics()
@@ -240,7 +240,7 @@ class TypingClassWithGenerics(_TypingClassMixin, ProxyWithGenerics):
         )
 
 
-class ProxyTypingClassValue(_TypingClassMixin, ProxyTypingValue):
+class ProxyTypingClassValue(ProxyTypingValue, _TypingClassMixin):
     index_class = TypingClassWithGenerics
 
 

--- a/jedi/inference/value/instance.py
+++ b/jedi/inference/value/instance.py
@@ -288,6 +288,11 @@ class _BaseTreeInstance(AbstractInstanceValue):
         """
         # Arguments in __get__ descriptors are obj, class.
         # `method` is the new parent of the array, don't know if that's good.
+        for cls in self.class_value.py__mro__():
+            result = cls.py__get__on_class(self, instance, class_value)
+            if result is not NotImplemented:
+                return result
+
         names = self.get_function_slot_names(u'__get__')
         if names:
             if instance is None:

--- a/jedi/inference/value/iterable.py
+++ b/jedi/inference/value/iterable.py
@@ -58,13 +58,13 @@ class GeneratorBase(LazyAttributeOverwrite, IterableMixin):
         return True
 
     @publish_method('__iter__')
-    def py__iter__(self, contextualized_node=None):
+    def _iter(self, arguments):
         return ValueSet([self])
 
     @publish_method('send')
     @publish_method('next', python_version_match=2)
     @publish_method('__next__', python_version_match=3)
-    def py__next__(self):
+    def py__next__(self, arguments):
         return ValueSet.from_sets(lazy_value.infer() for lazy_value in self.py__iter__())
 
     def py__stop_iteration_returns(self):
@@ -290,12 +290,12 @@ class DictComprehension(ComprehensionMixin, Sequence, _DictKeyMixin):
         return ValueSet.from_sets(values for keys, values in self._iterate())
 
     @publish_method('values')
-    def _imitate_values(self):
+    def _imitate_values(self, arguments):
         lazy_value = LazyKnownValues(self._dict_values())
         return ValueSet([FakeList(self.inference_state, [lazy_value])])
 
     @publish_method('items')
-    def _imitate_items(self):
+    def _imitate_items(self, arguments):
         lazy_values = [
             LazyKnownValue(
                 FakeTuple(
@@ -457,12 +457,12 @@ class DictLiteralValue(_DictMixin, SequenceLiteralValue, _DictKeyMixin):
             yield LazyKnownValues(types)
 
     @publish_method('values')
-    def _imitate_values(self):
+    def _imitate_values(self, arguments):
         lazy_value = LazyKnownValues(self._dict_values())
         return ValueSet([FakeList(self.inference_state, [lazy_value])])
 
     @publish_method('items')
-    def _imitate_items(self):
+    def _imitate_items(self, arguments):
         lazy_values = [
             LazyKnownValue(FakeTuple(
                 self.inference_state,
@@ -552,7 +552,7 @@ class FakeDict(_DictMixin, Sequence, _DictKeyMixin):
         return lazy_value.infer()
 
     @publish_method('values')
-    def _values(self):
+    def _values(self, arguments):
         return ValueSet([FakeTuple(
             self.inference_state,
             [LazyKnownValues(self._dict_values())]

--- a/jedi/inference/value/klass.py
+++ b/jedi/inference/value/klass.py
@@ -227,6 +227,11 @@ class ClassMixin(object):
         # Since calling staticmethod without a function is illegal, the Jedi
         # plugin doesn't return anything. Therefore call directly and get what
         # we want: An instance of staticmethod.
+        metaclasses = self.get_metaclasses()
+        if metaclasses:
+            sigs = self.get_metaclass_signatures(metaclasses)
+            if sigs:
+                return sigs
         args = ValuesArguments([])
         init_funcs = self.py__call__(args).py__getattribute__('__init__')
         return [sig.bind(self) for sig in init_funcs.get_signatures()]
@@ -360,8 +365,8 @@ class ClassValue(use_metaclass(CachedMetaClass, ClassMixin, FunctionAndClassBase
         )]
 
     @plugin_manager.decorate()
-    def get_metaclass_filters(self, metaclass, is_instance):
-        debug.warning('Unprocessed metaclass %s', metaclass)
+    def get_metaclass_filters(self, metaclasses, is_instance):
+        debug.warning('Unprocessed metaclass %s', metaclasses)
         return []
 
     @inference_state_method_cache(default=NO_VALUES)
@@ -381,3 +386,7 @@ class ClassValue(use_metaclass(CachedMetaClass, ClassMixin, FunctionAndClassBase
                     if values:
                         return values
         return NO_VALUES
+
+    @plugin_manager.decorate()
+    def get_metaclass_signatures(self, metaclasses):
+        return []

--- a/jedi/inference/value/klass.py
+++ b/jedi/inference/value/klass.py
@@ -189,7 +189,8 @@ class ClassMixin(object):
                             mro.append(cls_new)
                             yield cls_new
 
-    def get_filters(self, origin_scope=None, is_instance=False, include_metaclasses=True):
+    def get_filters(self, origin_scope=None, is_instance=False,
+                    include_metaclasses=True, include_type_when_class=True):
         if include_metaclasses:
             metaclasses = self.get_metaclasses()
             if metaclasses:
@@ -206,7 +207,7 @@ class ClassMixin(object):
                     origin_scope=origin_scope,
                     is_instance=is_instance
                 )
-        if not is_instance:
+        if not is_instance and include_type_when_class:
             from jedi.inference.compiled import builtin_from_name
             type_ = builtin_from_name(self.inference_state, u'type')
             assert isinstance(type_, ClassValue)

--- a/jedi/inference/value/klass.py
+++ b/jedi/inference/value/klass.py
@@ -271,6 +271,22 @@ class ClassMixin(object):
                         return True
         return False
 
+    def py__getitem__(self, index_value_set, contextualized_node):
+        from jedi.inference.gradual.base import GenericClass
+        if not index_value_set:
+            debug.warning('Class indexes inferred to nothing. Returning class instead')
+            return ValueSet([self])
+        return ValueSet(
+            GenericClass(
+                self,
+                LazyGenericManager(
+                    context_of_index=contextualized_node.context,
+                    index_value=index_value,
+                )
+            )
+            for index_value in index_value_set
+        )
+
     def with_generics(self, generics_tuple):
         from jedi.inference.gradual.base import GenericClass
         return GenericClass(
@@ -344,22 +360,6 @@ class ClassValue(use_metaclass(CachedMetaClass, ClassMixin, FunctionAndClassBase
         return [LazyKnownValues(
             self.inference_state.builtins_module.py__getattribute__('object')
         )]
-
-    def py__getitem__(self, index_value_set, contextualized_node):
-        from jedi.inference.gradual.base import GenericClass
-        if not index_value_set:
-            debug.warning('Class indexes inferred to nothing. Returning class instead')
-            return ValueSet([self])
-        return ValueSet(
-            GenericClass(
-                self,
-                LazyGenericManager(
-                    context_of_index=contextualized_node.context,
-                    index_value=index_value,
-                )
-            )
-            for index_value in index_value_set
-        )
 
     @plugin_manager.decorate()
     def get_metaclass_filters(self, metaclass, is_instance):

--- a/jedi/inference/value/klass.py
+++ b/jedi/inference/value/klass.py
@@ -193,7 +193,7 @@ class ClassMixin(object):
         if include_metaclasses:
             metaclasses = self.get_metaclasses()
             if metaclasses:
-                for f in self.get_metaclass_filters(metaclasses):
+                for f in self.get_metaclass_filters(metaclasses, is_instance):
                     yield f
 
         for cls in self.py__mro__():
@@ -361,8 +361,8 @@ class ClassValue(use_metaclass(CachedMetaClass, ClassMixin, FunctionAndClassBase
         return ValueSet({self})
 
     @plugin_manager.decorate()
-    def get_metaclass_filters(self, metaclass):
-        debug.dbg('Unprocessed metaclass %s', metaclass)
+    def get_metaclass_filters(self, metaclass, is_instance):
+        debug.warning('Unprocessed metaclass %s', metaclass)
         return []
 
     @inference_state_method_cache(default=NO_VALUES)

--- a/jedi/inference/value/klass.py
+++ b/jedi/inference/value/klass.py
@@ -114,8 +114,6 @@ class ClassFilter(ParserTreeFilter):
             if expr_stmt is not None and expr_stmt.type == 'expr_stmt':
                 annassign = expr_stmt.children[1]
                 if annassign.type == 'annassign':
-                    # TODO this is not proper matching
-
                     # If there is an =, the variable is obviously also
                     # defined on the class.
                     if 'ClassVar' not in annassign.children[1].get_code() \
@@ -138,7 +136,7 @@ class ClassMixin(object):
     def is_class_mixin(self):
         return True
 
-    def py__call__(self, arguments=None):
+    def py__call__(self, arguments):
         from jedi.inference.value import TreeInstance
 
         from jedi.inference.gradual.typing import TypedDict
@@ -195,7 +193,7 @@ class ClassMixin(object):
             metaclasses = self.get_metaclasses()
             if metaclasses:
                 for f in self.get_metaclass_filters(metaclasses, is_instance):
-                    yield f
+                    yield f  # Python 2..
 
         for cls in self.py__mro__():
             if cls.is_compiled():
@@ -203,7 +201,7 @@ class ClassMixin(object):
                     yield filter
             else:
                 yield ClassFilter(
-                    self, node_context=cls.as_context(),
+                    cls, node_context=self.as_context(),
                     origin_scope=origin_scope,
                     is_instance=is_instance
                 )

--- a/jedi/inference/value/klass.py
+++ b/jedi/inference/value/klass.py
@@ -135,6 +135,9 @@ class ClassMixin(object):
     def is_class(self):
         return True
 
+    def is_class_mixin(self):
+        return True
+
     def py__call__(self, arguments=None):
         from jedi.inference.value import TreeInstance
 
@@ -314,6 +317,7 @@ class ClassValue(use_metaclass(CachedMetaClass, ClassMixin, FunctionAndClassBase
     def py__getitem__(self, index_value_set, contextualized_node):
         from jedi.inference.gradual.base import GenericClass
         if not index_value_set:
+            debug.warning('Class indexes inferred to nothing. Returning class instead')
             return ValueSet([self])
         return ValueSet(
             GenericClass(

--- a/jedi/inference/value/klass.py
+++ b/jedi/inference/value/klass.py
@@ -201,7 +201,7 @@ class ClassMixin(object):
                     yield filter
             else:
                 yield ClassFilter(
-                    cls, node_context=self.as_context(),
+                    self, node_context=cls.as_context(),
                     origin_scope=origin_scope,
                     is_instance=is_instance
                 )

--- a/jedi/plugins/django.py
+++ b/jedi/plugins/django.py
@@ -154,7 +154,11 @@ def _new_dict_filter(cls, is_instance):
         if manager:
             return manager.name
 
-    filters = list(cls.get_filters(is_instance=True, include_metaclasses=False))
+    filters = list(cls.get_filters(
+        is_instance=is_instance,
+        include_metaclasses=False,
+        include_type_when_class=False)
+    )
     dct = {
         name.string_name: DjangoModelName(cls, name, is_instance)
         for filter_ in reversed(filters)

--- a/jedi/plugins/django.py
+++ b/jedi/plugins/django.py
@@ -102,7 +102,7 @@ def _create_manager_for(cls, manager_cls='BaseManager'):
         ('django', 'db', 'models', 'manager')
     ).py__getattribute__(manager_cls)
     for m in managers:
-        if m.is_class() and not m.is_compiled():
+        if m.is_class_mixin():
             generics_manager = TupleGenericManager((ValueSet([cls]),))
             for c in GenericClass(m, generics_manager).execute_annotation():
                 return c

--- a/jedi/plugins/django.py
+++ b/jedi/plugins/django.py
@@ -79,7 +79,8 @@ def _get_foreign_key_values(cls, field_tree_instance):
 
 def _infer_field(cls, field_name, is_instance):
     inference_state = cls.inference_state
-    for field_tree_instance in field_name.infer():
+    result = field_name.infer()
+    for field_tree_instance in result:
         scalar_field = _infer_scalar_field(
             inference_state, field_name, field_tree_instance, is_instance)
         if scalar_field is not None:
@@ -101,7 +102,7 @@ def _infer_field(cls, field_name, is_instance):
 
     debug.dbg('django plugin: fail to infer `%s` from class `%s`',
               field_name.string_name, cls.py__name__())
-    return field_name.infer()
+    return result
 
 
 class DjangoModelName(NameWrapper):

--- a/jedi/plugins/stdlib.py
+++ b/jedi/plugins/stdlib.py
@@ -395,7 +395,7 @@ class PropertyObject(AttributeOverwrite, ValueWrapper):
 
     def py__get__(self, instance, class_value):
         if instance is None:
-            return NO_VALUES
+            return ValueSet([self])
         return self._function.execute_with_values(instance)
 
     @publish_method('deleter')
@@ -518,6 +518,8 @@ class PartialObject(ValueWrapper):
 
 class PartialMethodObject(PartialObject):
     def py__get__(self, instance, class_value):
+        if instance is None:
+            return ValueSet([self])
         return ValueSet([PartialObject(self._actual_value, self._arguments, instance)])
 
 

--- a/jedi/plugins/stdlib.py
+++ b/jedi/plugins/stdlib.py
@@ -801,7 +801,7 @@ _implemented = {
 
 
 def get_metaclass_filters(func):
-    def wrapper(cls, metaclasses):
+    def wrapper(cls, metaclasses, is_instance):
         for metaclass in metaclasses:
             if metaclass.py__name__() == 'EnumMeta' \
                     and metaclass.get_root_context().py__name__() == 'enum':
@@ -809,7 +809,7 @@ def get_metaclass_filters(func):
                 return [DictFilter({
                     name.string_name: EnumInstance(cls, name).name for name in filter_.values()
                 })]
-        return func(cls, metaclasses)
+        return func(cls, metaclasses, is_instance)
     return wrapper
 
 

--- a/jedi/plugins/stdlib.py
+++ b/jedi/plugins/stdlib.py
@@ -260,13 +260,12 @@ class ReversedObject(AttributeOverwrite):
         super(ReversedObject, self).__init__(reversed_obj)
         self._iter_list = iter_list
 
-    @publish_method('__iter__')
-    def py__iter__(self, contextualized_node=None):
+    def py__iter__(self, contextualized_node):
         return self._iter_list
 
     @publish_method('next', python_version_match=2)
     @publish_method('__next__', python_version_match=3)
-    def py__next__(self):
+    def py__next__(self, arguments):
         return ValueSet.from_sets(
             lazy_value.infer() for lazy_value in self._iter_list
         )
@@ -401,7 +400,7 @@ class PropertyObject(AttributeOverwrite, ValueWrapper):
     @publish_method('deleter')
     @publish_method('getter')
     @publish_method('setter')
-    def _return_self(self):
+    def _return_self(self, arguments):
         return ValueSet({self})
 
 

--- a/test/completion/django.py
+++ b/test/completion/django.py
@@ -4,6 +4,7 @@ import uuid
 
 from django.db import models
 from django.contrib.auth.models import User
+from django.db.models.query_utils import DeferredAttribute
 
 
 class TagManager(models.Manager):
@@ -58,12 +59,20 @@ class BusinessModel(models.Model):
 
     unidentifiable = NOT_FOUND
 
+    #? models.IntegerField()
+    integer_field
+
     def method(self):
         return 42
 
 # -----------------
 # Model attribute inference
 # -----------------
+
+#? DeferredAttribute()
+BusinessModel.integer_field
+#? DeferredAttribute()
+BusinessModel.tags_m2m
 
 model_instance = BusinessModel()
 

--- a/test/completion/django.py
+++ b/test/completion/django.py
@@ -73,6 +73,8 @@ class BusinessModel(models.Model):
 BusinessModel.integer_field
 #? DeferredAttribute()
 BusinessModel.tags_m2m
+#? DeferredAttribute()
+BusinessModel.email_field
 
 model_instance = BusinessModel()
 
@@ -250,3 +252,24 @@ BusinessModel.objects.values_list('char_field')[0]
 BusinessModel.objects.values('char_field')[0]
 #?
 BusinessModel.objects.values('char_field')[0]['char_field']
+
+# -----------------
+# Completion
+# -----------------
+
+#? 19 ['text_field=']
+Inherited(text_fiel)
+#? 18 ['new_field=']
+Inherited(new_fiel)
+#? 19 ['char_field=']
+Inherited(char_fiel)
+#? 19 ['email_field=']
+Inherited(email_fie)
+#? 19 []
+Inherited(unidentif)
+#? 21 ['category_fk=', 'category_fk2=', 'category_fk3=', 'category_fk4=', 'category_fk5=']
+Inherited(category_fk)
+#? 21 ['attached_o2o=']
+Inherited(attached_o2)
+#? 18 ['tags_m2m=']
+Inherited(tags_m2m)

--- a/test/completion/django.py
+++ b/test/completion/django.py
@@ -162,16 +162,22 @@ model_instance.method
 # Queries
 # -----------------
 
-#? models.query.QuerySet.filter
+#? ['objects']
+model_instance.object
+#?
+model_instance.objects
+#?
 model_instance.objects.filter
+#? models.query.QuerySet.filter
+BusinessModel.objects.filter
 #? BusinessModel() None
-model_instance.objects.filter().first()
+BusinessModel.objects.filter().first()
 #? str()
-model_instance.objects.get().char_field
+BusinessModel.objects.get().char_field
 #? int()
-model_instance.objects.update(x='')
+BusinessModel.objects.update(x='')
 #? BusinessModel()
-model_instance.objects.create()
+BusinessModel.objects.create()
 
 # -----------------
 # Custom object manager
@@ -179,9 +185,13 @@ model_instance.objects.create()
 
 #? TagManager()
 Tag.objects
+#? Tag() None
+Tag.objects.filter().first()
 
 #? TagManager()
 Tag.custom_objects
+#? Tag() None
+Tag.custom_objects.filter().first()
 
 # -----------------
 # Inheritance
@@ -199,14 +209,27 @@ inherited.char_field
 #? float()
 inherited.new_field
 
+#?
+Inherited.category_fk2.category_name
 #? str()
 inherited.category_fk2.category_name
 #? str()
-inherited.objects.get().char_field
+Inherited.objects.get().char_field
 #? int()
-inherited.objects.get().text_field
+Inherited.objects.get().text_field
 #? float()
-inherited.objects.get().new_field
+Inherited.objects.get().new_field
+
+# -----------------
+# Model methods
+# -----------------
+
+#? ['from_db']
+Inherited.from_db
+#? ['validate_unique']
+Inherited.validate_uniqu
+#? ['validate_unique']
+Inherited().validate_unique
 
 # -----------------
 # Django Auth
@@ -222,8 +245,8 @@ User.objects.get().email
 # -----------------
 
 #?
-model_instance.objects.values_list('char_field')[0]
+BusinessModel.objects.values_list('char_field')[0]
 #? dict()
-model_instance.objects.values('char_field')[0]
+BusinessModel.objects.values('char_field')[0]
 #?
-model_instance.objects.values('char_field')[0]['char_field']
+BusinessModel.objects.values('char_field')[0]['char_field']

--- a/test/completion/django.py
+++ b/test/completion/django.py
@@ -273,3 +273,20 @@ Inherited(category_fk)
 Inherited(attached_o2)
 #? 18 ['tags_m2m=']
 Inherited(tags_m2m)
+
+#? 32 ['tags_m2m=']
+Inherited.objects.create(tags_m2)
+#? 32 ['tags_m2m=']
+Inherited.objects.filter(tags_m2)
+#? 35 ['char_field=']
+Inherited.objects.exclude(char_fiel)
+#? 34 ['char_field=']
+Inherited.objects.update(char_fiel)
+#? 32 ['email_field=']
+Inherited.objects.get(email_fiel)
+#? 44 ['category_fk2=']
+Inherited.objects.get_or_create(category_fk2)
+#? 44 ['uuid_field=']
+Inherited.objects.update_or_create(uuid_fiel)
+#? 48 ['char_field=']
+Inherited.objects.exclude(pk=3).filter(char_fiel)

--- a/test/completion/pep0484_generic_passthroughs.py
+++ b/test/completion/pep0484_generic_passthroughs.py
@@ -126,3 +126,19 @@ for p in typed_bound_generic_passthrough(untyped_list_str):
 for q in typed_bound_generic_passthrough(typed_list_str):
     #? str()
     q
+
+
+class CustomList(List):
+    def get_first(self):
+        return self[0]
+
+
+#? str()
+CustomList[str]()[0]
+#? str()
+CustomList[str]().get_first()
+
+#? str()
+typed_fully_generic_passthrough(CustomList[str]())[0]
+#?
+typed_list_generic_passthrough(CustomList[str])[0]


### PR DESCRIPTION
Includes #1593 

This uses `py__get__`, which seems to work very well.

@PeterJCLaw This got way more complicated than I initially imagined. I think most changes here are internal changes in Jedi to make this possible, but it's still a bit worrying that this was so complicated.

Feel free to not really review this deeply. Just wanted to let you review it, because you essentially wrote the code that we depend on.