### PR TITLE
Add Python 3.8 to the tox env list

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py35, py36, py37, qa
+envlist = py27, py35, py36, py37, py38, qa
 [testenv]
 extras = testing
 deps =
@@ -25,6 +25,7 @@ setenv =
     env35: JEDI_TEST_ENVIRONMENT=35
     env36: JEDI_TEST_ENVIRONMENT=36
     env37: JEDI_TEST_ENVIRONMENT=37
+    env38: JEDI_TEST_ENVIRONMENT=38
     interpreter: JEDI_TEST_ENVIRONMENT=interpreter
 commands =
     pytest {posargs}


### PR DESCRIPTION
Since Python 3.8 is tested on CI, we should have it in the tox.ini too.

Should we have 3.9 there as well?