### PR TITLE
Add __matmul__ to supported operators.

### DIFF
--- a/jedi/inference/syntax_tree.py
+++ b/jedi/inference/syntax_tree.py
@@ -35,6 +35,7 @@ operator_to_magic_method = {
     '+': '__add__',
     '-': '__sub__',
     '*': '__mul__',
+    '@': '__matmul__',
     '/': '__truediv__',
     '//': '__floordiv__',
     '%': '__mod__',


### PR DESCRIPTION
This resolves an exception during inference for code with using the `@` operator.

I've been getting a `KeyError` when analyzing code containing this operator:
```
...
  File "/usr/local/lib/python3.8/site-packages/jedi/api/__init__.py", line 311, in infer
    return self._infer(line, column, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/jedi/api/__init__.py", line 331, in _infer
    values = helpers.infer(self._inference_state, context, leaf)
  File "/usr/local/lib/python3.8/site-packages/jedi/api/helpers.py", line 164, in infer
    return inference_state.infer(context, leaf)
  File "/usr/local/lib/python3.8/site-packages/jedi/inference/__init__.py", line 161, in infer
    return infer_expr_stmt(context, def_, name)
  File "/usr/local/lib/python3.8/site-packages/jedi/inference/syntax_tree.py", line 82, in wrapper
    return func(context, *args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/jedi/inference/syntax_tree.py", line 384, in infer_expr_stmt
    return _infer_expr_stmt(context, stmt, seek_name)
  File "/usr/local/lib/python3.8/site-packages/jedi/debug.py", line 82, in wrapper
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/jedi/inference/syntax_tree.py", line 417, in _infer_expr_stmt
    value_set = context.infer_node(rhs)
  File "/usr/local/lib/python3.8/site-packages/jedi/inference/context.py", line 222, in infer_node
    return infer_node(self, node)
  File "/usr/local/lib/python3.8/site-packages/jedi/inference/syntax_tree.py", line 156, in infer_node
    return _infer_node_if_inferred(context, element)
  File "/usr/local/lib/python3.8/site-packages/jedi/inference/syntax_tree.py", line 169, in _infer_node_if_inferred
    return _infer_node_cached(context, element)
  File "/usr/local/lib/python3.8/site-packages/jedi/inference/cache.py", line 44, in wrapper
    rv = function(obj, *args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/jedi/inference/syntax_tree.py", line 174, in _infer_node_cached
    return _infer_node(context, element)
  File "/usr/local/lib/python3.8/site-packages/jedi/debug.py", line 82, in wrapper
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/jedi/inference/syntax_tree.py", line 82, in wrapper
    return func(context, *args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/jedi/inference/syntax_tree.py", line 256, in _infer_node
    return infer_or_test(context, element)
  File "/usr/local/lib/python3.8/site-packages/jedi/inference/syntax_tree.py", line 485, in infer_or_test
    types = _infer_comparison(context, types, operator,
  File "/usr/local/lib/python3.8/site-packages/jedi/inference/syntax_tree.py", line 537, in _infer_comparison
    return ValueSet.from_sets(
  File "/usr/local/lib/python3.8/site-packages/jedi/inference/base_value.py", line 424, in from_sets
    for set_ in sets:
  File "/usr/local/lib/python3.8/site-packages/jedi/inference/syntax_tree.py", line 538, in <genexpr>
    _infer_comparison_part(state, context, left, operator, right)
  File "/usr/local/lib/python3.8/site-packages/jedi/inference/syntax_tree.py", line 662, in _infer_comparison_part
    method_name = operator_to_magic_method[str_operator]
KeyError: '@'
```

PS. Thanks for your great project!