### PR TITLE
Fix #1629

### DIFF
--- a/jedi/api/environment.py
+++ b/jedi/api/environment.py
@@ -61,7 +61,7 @@ class Environment(_BaseEnvironment):
     """
     _subprocess = None
 
-    def __init__(self, executable, env_vars={}):
+    def __init__(self, executable, env_vars=None):
         self._start_executable = executable
         self._env_vars = env_vars
         # Initialize the environment
@@ -136,7 +136,7 @@ class _SameEnvironmentMixin(object):
         self._start_executable = self.executable = sys.executable
         self.path = sys.prefix
         self.version_info = _VersionInfo(*sys.version_info[:3])
-        self._env_vars = {}
+        self._env_vars = None
 
 
 class SameEnvironment(_SameEnvironmentMixin, Environment):

--- a/jedi/inference/compiled/subprocess/__init__.py
+++ b/jedi/inference/compiled/subprocess/__init__.py
@@ -156,20 +156,11 @@ class CompiledSubprocess(object):
     # Start with 2, gets set after _get_info.
     _pickle_protocol = 2
 
-    def __init__(self, executable, env_vars={}):
+    def __init__(self, executable, env_vars=None):
         self._executable = executable
-        self._env_vars = dict(env_vars)
+        self._env_vars = env_vars
         self._inference_state_deletion_queue = queue.deque()
         self._cleanup_callable = lambda: None
-
-        # Use explicit envionment to ensure reliable results (#1540)
-        if os.name == 'nt':
-            # if SYSTEMROOT (or case variant) exists in environment,
-            # ensure it goes to subprocess
-            for k, v in os.environ.items():
-                if 'SYSTEMROOT' == k.upper():
-                    self._env_vars.update({k: os.environ[k]})
-                    break  # don't risk multiple entries
 
     def __repr__(self):
         pid = os.getpid()


### PR DESCRIPTION
* reflect default Popen behavior by inheriting os.environ
* without passing env_vars to create_environment, GeneralizedPopen behavior is same as before fix to issue #1540 (803c3cb271ead297c4fe3ca916b54ed05a623459)
* env_vars allows explicit environment variables, per PR #1619 (f9183bbf6436fc4c4a384c7c8dcb45324c8720f6)