### PR TITLE
Python 3.6 embeddable doesn't have pydoc_data

### DIFF
--- a/jedi/api/keywords.py
+++ b/jedi/api/keywords.py
@@ -3,7 +3,11 @@ from contextlib import suppress
 
 from jedi.inference.names import AbstractArbitraryName
 
-from pydoc_data import topics as pydoc_topics
+try:
+    from pydoc_data import topics as pydoc_topics
+except ImportError:
+    # Python 3.6.8 embeddable does not have pydoc_data.
+    pydoc_topics = None
 
 
 class KeywordName(AbstractArbitraryName):


### PR DESCRIPTION
This reinstates the import check for pydoc_data for now.

Specifically I looked in the following:
- [python-3.6.8-embed-amd64.zip](https://www.python.org/ftp/python/3.6.8/python-3.6.8-embed-amd64.zip): missing pydoc_data
- [python-3.7.8-embed-amd64.zip](https://www.python.org/ftp/python/3.7.8/python-3.7.8-embed-amd64.zip): present
- [python-3.8.5-embed-amd64.zip](https://www.python.org/ftp/python/3.8.5/python-3.8.5-embed-amd64.zip): present

Found while adding types; I've not actually tested this beyond inspecting the zips.