### PR TITLE
Fix #1655 by using platform-correct path handling for relative imports

### DIFF
--- a/test/examples/issue1655/subdir/file3.py
+++ b/test/examples/issue1655/subdir/file3.py
@@ -1,0 +1,2 @@
+def do_nothing_file3():
+    pass

--- a/test/test_inference/test_imports.py
+++ b/test/test_inference/test_imports.py
@@ -544,6 +544,10 @@ def test_level_to_import_path(
     project_path: str,
     result: Tuple[Optional[List[str]], Optional[str]],
 ) -> None:
+    # Convert for path separators being different on Windows
+    subdirs, root = result
+    result = subdirs, None if root is None else str(Path(root))
+
     assert imports._level_to_base_import_path(
         Path(project_path),
         Path(directory),


### PR DESCRIPTION
This fixes an issue which showed up on Windows in 0.17.x where the VSCode Python extension passes paths which have their drive letter normalised to lower case. Since paths are (mostly) case insensitive on Windows, that shouldn't matter. However Jedi's handling was `==` on `str`s, meaning that completions based on relative imports on windows didn't work.

On master this same issue had started appearing due to the partial migration to use `Path` instead of `str` (which will avoid such issues entirely once complete), as `Path` instances were being compared to `str` instances without first converting.

We fix both by clarifying which is used here and then doing the proper conversions.