### PR TITLE
make contextualized_node an optional kwarg in ReversedObject

### DIFF
--- a/jedi/plugins/stdlib.py
+++ b/jedi/plugins/stdlib.py
@@ -257,7 +257,7 @@ class ReversedObject(AttributeOverwrite):
         super().__init__(reversed_obj)
         self._iter_list = iter_list
 
-    def py__iter__(self, contextualized_node):
+    def py__iter__(self, contextualized_node=None):
         return self._iter_list
 
     @publish_method('__next__')


### PR DESCRIPTION
In all other py__iter__ definitions that I found, this argument is optional. It also often seems to not be passed around. I'm not sure why it was deemed mandatory here despite not being used.