### PR TITLE
Relative imports should work even if they are not within the project

### DIFF
--- a/jedi/inference/imports.py
+++ b/jedi/inference/imports.py
@@ -252,7 +252,7 @@ class Importer:
                 # relative imports the wrong way, we might end up here, where
                 # the `fixed_sys_path == project.path` in that case we kind of
                 # use the project.path.parent directory as our path. This is
-                # usually not a problem, except if imorts in other places are
+                # usually not a problem, except if imports in other places are
                 # using the same names. Example:
                 #
                 # foo/                       < #1

--- a/jedi/inference/imports.py
+++ b/jedi/inference/imports.py
@@ -267,6 +267,10 @@ class Importer:
                 # `__init__.py` (#2) and not as `foo.py` (#3). This is usually
                 # not an issue, because this case is probably pretty rare, but
                 # might be an issue for some people.
+                #
+                # However for most normal cases where we work with different
+                # file names, this code path hits where we basically change the
+                # project path to an ancestor of project path.
                 from jedi.inference.value.namespace import ImplicitNamespaceValue
                 import_path = (os.path.basename(self._fixed_sys_path[0]),)
                 ns = ImplicitNamespaceValue(

--- a/jedi/inference/imports.py
+++ b/jedi/inference/imports.py
@@ -245,7 +245,38 @@ class Importer:
         )
 
     def follow(self):
-        if not self.import_path or not self._infer_possible:
+        if not self.import_path:
+            if self._fixed_sys_path:
+                # This is a bit of a special case, that maybe should be
+                # revisited. If the project path is wrong or the user uses
+                # relative imports the wrong way, we might end up here, where
+                # the `fixed_sys_path == project.path` in that case we kind of
+                # use the project.path.parent directory as our path. This is
+                # usually not a problem, except if imorts in other places are
+                # using the same names. Example:
+                #
+                # foo/                       < #1
+                #   - setup.py
+                #   - foo/                   < #2
+                #     - __init__.py
+                #     - foo.py               < #3
+                #
+                # If the top foo is our project folder and somebody uses
+                # `from . import foo` in `setup.py`, it will resolve to foo #2,
+                # which means that the import for foo.foo is cached as
+                # `__init__.py` (#2) and not as `foo.py` (#3). This is usually
+                # not an issue, because this case is probably pretty rare, but
+                # might be an issue for some people.
+                from jedi.inference.value.namespace import ImplicitNamespaceValue
+                import_path = (os.path.basename(self._fixed_sys_path[0]),)
+                ns = ImplicitNamespaceValue(
+                    self._inference_state,
+                    string_names=import_path,
+                    paths=self._fixed_sys_path,
+                )
+                return ValueSet({ns})
+            return NO_VALUES
+        if not self._infer_possible:
             return NO_VALUES
 
         # Check caches first

--- a/test/test_api/test_usages.py
+++ b/test/test_api/test_usages.py
@@ -1,8 +1,10 @@
 import pytest
 
+from ..helpers import test_dir
+
 
 def test_import_references(Script):
-    s = Script("from .. import foo", path="foo.py")
+    s = Script("from .. import foo", path=test_dir.joinpath("foo.py"))
     assert [usage.line for usage in s.get_references()] == [1]
 
 

--- a/test/test_api/test_usages.py
+++ b/test/test_api/test_usages.py
@@ -3,7 +3,7 @@ import pytest
 
 def test_import_references(Script):
     s = Script("from .. import foo", path="foo.py")
-    assert [usage.line for usage in s.get_references(line=1, column=18)] == [1]
+    assert [usage.line for usage in s.get_references()] == [1]
 
 
 def test_exclude_builtin_modules(Script):

--- a/test/test_inference/test_imports.py
+++ b/test/test_inference/test_imports.py
@@ -475,7 +475,7 @@ def test_relative_import_star(Script):
 def test_relative_imports_without_path_and_setup_py(
         Script, inference_state, environment, tmpdir, with_init):
     # Contrary to other tests here we create a temporary folder that is not
-    # part of a folder with a setup py that signifies
+    # part of a folder with a setup.py that signifies
     tmpdir.join('file1.py').write('do_foo = 1')
     other_path = tmpdir.join('other_files')
     other_path.join('file2.py').write('def do_nothing():\n pass', ensure=True)


### PR DESCRIPTION
See comments in code.

This is another potential solution for #1655 (and an answer to #1662 as well).

@PeterJCLaw I was a bit confused in the beginning why this was happening, but I understand it better now. This was an issue on all platforms. We could of course still use #1662 or at least parts of it, but I guess this is the more important part.