### PR TITLE
Catch 'PermissionError' for unreadable directories

### DIFF
--- a/jedi/api/project.py
+++ b/jedi/api/project.py
@@ -366,8 +366,11 @@ class Project:
 
 def _is_potential_project(path):
     for name in _CONTAINS_POTENTIAL_PROJECT:
-        if path.joinpath(name).exists():
-            return True
+        try:
+            if path.joinpath(name).exists():
+                return True
+        except PermissionError:
+            continue
     return False
 
 

--- a/jedi/api/project.py
+++ b/jedi/api/project.py
@@ -369,7 +369,7 @@ def _is_potential_project(path):
         try:
             if path.joinpath(name).exists():
                 return True
-        except PermissionError:
+        except OSError:
             continue
     return False
 

--- a/jedi/inference/sys_path.py
+++ b/jedi/inference/sys_path.py
@@ -174,7 +174,7 @@ def _get_parent_dir_with_file(path: Path, filename):
         try:
             if parent.joinpath(filename).is_file():
                 return parent
-        except PermissionError:
+        except OSError:
             continue
     return None
 

--- a/jedi/inference/sys_path.py
+++ b/jedi/inference/sys_path.py
@@ -171,8 +171,11 @@ def _get_paths_from_buildout_script(inference_state, buildout_script_path):
 
 def _get_parent_dir_with_file(path: Path, filename):
     for parent in path.parents:
-        if parent.joinpath(filename).is_file():
-            return parent
+        try:
+            if parent.joinpath(filename).is_file():
+                return parent
+        except PermissionError:
+            continue
     return None
 
 

--- a/test/test_api/test_project.py
+++ b/test/test_api/test_project.py
@@ -6,6 +6,7 @@ import pytest
 from ..helpers import get_example_dir, set_cwd, root_dir, test_dir
 from jedi import Interpreter
 from jedi.api import Project, get_default_project
+from jedi.api.project import _is_potential_project, _CONTAINS_POTENTIAL_PROJECT
 
 
 def test_django_default_project(Script):
@@ -160,3 +161,21 @@ def test_complete_search(Script, string, completions, all_scopes):
     project = Project(test_dir)
     defs = project.complete_search(string, all_scopes=all_scopes)
     assert [d.complete for d in defs] == completions
+
+
+@pytest.mark.parametrize(
+    'path,expected', [
+        (Path(__file__).parents[2], True), # The path of the project
+        (Path(__file__).parents[1], False), # The path of the tests, not a project
+        (Path.home(), None)
+    ]
+)
+def test_is_potential_project(path, expected):
+
+    if expected is None:
+        try:
+            expected = _CONTAINS_POTENTIAL_PROJECT in os.listdir(path)
+        except OSError:
+            expected = False
+
+    assert _is_potential_project(path) == expected

--- a/test/test_inference/test_sys_path.py
+++ b/test/test_inference/test_sys_path.py
@@ -108,3 +108,13 @@ def test_transform_path_to_dotted(sys_path_, module_path, expected, is_package):
     module_path = os.path.abspath(module_path)
     assert sys_path.transform_path_to_dotted(sys_path_, Path(module_path)) \
         == (expected, is_package)
+
+
+@pytest.mark.parametrize(
+    'path,filename,expected', [
+        (Path(__file__).parents[1], "setup.py", Path(__file__).parents[2]),
+        (Path(__file__).parents[2], os.path.basename(__file__), None)
+    ]
+)
+def test_get_parent_dir_with_file(path, filename, expected):
+    assert sys_path._get_parent_dir_with_file(path, filename) == expected

--- a/test/test_inference/test_sys_path.py
+++ b/test/test_inference/test_sys_path.py
@@ -108,13 +108,3 @@ def test_transform_path_to_dotted(sys_path_, module_path, expected, is_package):
     module_path = os.path.abspath(module_path)
     assert sys_path.transform_path_to_dotted(sys_path_, Path(module_path)) \
         == (expected, is_package)
-
-
-@pytest.mark.parametrize(
-    'path,filename,expected', [
-        (Path(__file__).parents[1], "setup.py", Path(__file__).parents[2]),
-        (Path(__file__).parents[2], os.path.basename(__file__), None)
-    ]
-)
-def test_get_parent_dir_with_file(path, filename, expected):
-    assert sys_path._get_parent_dir_with_file(path, filename) == expected


### PR DESCRIPTION
Hi. The master branch of Jedi raises a `PermissionError` on iOS. I added two try excepts on code that assumes a directory is readable. That may be useful on other platforms too. That was the error:

```Traceback (most recent call last):
  File "/private/var/containers/Bundle/Application/2FB8EF9C-46B5-4A69-8D4F-0D1115D2BED0/Pyto.app/Lib/_codecompletion.py", line 59, in suggestForCode
    script = jedi.Script(code, path=path)
  File "/private/var/containers/Bundle/Application/2FB8EF9C-46B5-4A69-8D4F-0D1115D2BED0/Pyto.app/site-packages/jedi/api/__init__.py", line 145, in __init__
    project = get_default_project(None if self.path is None else self.path.parent)
  File "/private/var/containers/Bundle/Application/2FB8EF9C-46B5-4A69-8D4F-0D1115D2BED0/Pyto.app/site-packages/jedi/api/project.py", line 422, in get_default_project
    if probable_path is None and _is_potential_project(dir):
  File "/private/var/containers/Bundle/Application/2FB8EF9C-46B5-4A69-8D4F-0D1115D2BED0/Pyto.app/site-packages/jedi/api/project.py", line 369, in _is_potential_project
    if path.joinpath(name).exists():
  File "/var/mobile/Containers/Data/Application/4A635FFF-9668-44D3-9A19-6D54C2D289FF/Library/python38/pathlib.py", line 1370, in exists
    self.stat()
  File "/var/mobile/Containers/Data/Application/4A635FFF-9668-44D3-9A19-6D54C2D289FF/Library/python38/pathlib.py", line 1176, in stat
    return self._accessor.stat(self)
PermissionError: [Errno 1] Operation not permitted: '/private/var/mobile/Library/Mobile Documents/setup.py'
```

`/private/var/mobile/Library/Mobile Documents` is the directory where all iCloud Drive files are stored, but it's sandboxed so apps can only read their own container which are located in this directory.

Sorry, I don't think iOS is a priority here, but other computers with strict permissions could also raise this error so I think it would be better anyway to handle those cases.