### PR TITLE
Add tests for #1702, for a rare numpydoc syntax.

### DIFF
--- a/jedi/inference/docstrings.py
+++ b/jedi/inference/docstrings.py
@@ -113,7 +113,7 @@ def _expand_typestr(type_str):
     elif type_str.startswith('{'):
         node = parse(type_str, version='3.7').children[0]
         if node.type == 'atom':
-            for leaf in node.children[1].children:
+            for leaf in getattr(node.children[1], "children", []):
                 if leaf.type == 'number':
                     if '.' in leaf.value:
                         yield 'float'

--- a/test/test_inference/test_docstring.py
+++ b/test/test_inference/test_docstring.py
@@ -206,6 +206,24 @@ def test_numpydoc_parameters_set_of_values():
     assert 'capitalize' in names
     assert 'numerator' in names
 
+@pytest.mark.skipif(numpydoc_unavailable,
+                    reason='numpydoc module is unavailable')
+def test_numpydoc_parameters_set_single_value():
+    """
+    This is found in numpy  masked-array I'm not too sure what this means but should not crash
+    """
+    s = dedent('''
+    def foobar(x, y):
+        """
+        Parameters
+        ----------
+        x : {var}, optional
+        """
+        x.''')
+    names = [c.name for c in jedi.Script(s).complete()]
+    # just don't crash
+    assert names == []
+
 
 @pytest.mark.skipif(numpydoc_unavailable,
                     reason='numpydoc module is unavailable')


### PR DESCRIPTION
It looks like numpydoc, and things like masked array docstrings use a
syntax that make jedi crash:

    fill_value : {var}, optional
            Value used internally for the masked values.
            If ``fill_value`` is not None, it supersedes ``endwith``.

Here we add a test that we do not crash jedi, and then a commit that only lookup children the node have a children attribute. 



