### PR TITLE
Check if string_names is None before returning string_names

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -60,6 +60,7 @@ Code Contributors
 - Max Mäusezahl (@mmaeusezahl) <maxmaeusezahl@googlemail.com>
 - Vladislav Serebrennikov (@endilll)
 - Andrii Kolomoiets (@muffinmad)
+- Leo Ryu (@Leo-Ryu)
 
 And a few more "anonymous" contributors.
 

--- a/jedi/inference/value/module.py
+++ b/jedi/inference/value/module.py
@@ -179,6 +179,9 @@ class ModuleValue(ModuleMixin, TreeValue):
         return self._is_package
 
     def py__package__(self):
+        if self.string_names is None:
+            return []
+            
         if self._is_package:
             return self.string_names
         return self.string_names[:-1]

--- a/jedi/inference/value/module.py
+++ b/jedi/inference/value/module.py
@@ -181,7 +181,7 @@ class ModuleValue(ModuleMixin, TreeValue):
     def py__package__(self):
         if self.string_names is None:
             return []
-            
+
         if self._is_package:
             return self.string_names
         return self.string_names[:-1]

--- a/test/test_inference/test_imports.py
+++ b/test/test_inference/test_imports.py
@@ -96,6 +96,9 @@ def test_correct_zip_package_behavior(Script, inference_state, environment, code
     if path is not None:
         assert value.py__path__() == [str(pkg_zip_path.joinpath(path))]
 
+    value.string_names = None
+    assert value.py__package__() == []
+
 
 def test_find_module_not_package_zipped(Script, inference_state, environment):
     path = get_example_dir('zipped_imports', 'not_pkg.zip')


### PR DESCRIPTION
Hello!

I'm using jedi for a personal project, and I was getting this error when generating references of a class.

This PR simply checks if `self.string_names` is None and returns an empty list if so-- it solves the issue on my personal project so I thought it might be of some use to others.

```
  File "/Users/lryu/.local/share/virtualenvs/python-parser-S0EswWrV/lib/python3.8/site-packages/jedi/api/helpers.py", line 487, in wrapper
    return func(self, line, column, *args, **kwargs)
  File "/Users/lryu/.local/share/virtualenvs/python-parser-S0EswWrV/lib/python3.8/site-packages/jedi/api/__init__.py", line 529, in get_references
    return _references(**kwargs)
  File "/Users/lryu/.local/share/virtualenvs/python-parser-S0EswWrV/lib/python3.8/site-packages/jedi/api/__init__.py", line 523, in _references
    names = find_references(self._get_module_context(), tree_name, scope == 'file')
  File "/Users/lryu/.local/share/virtualenvs/python-parser-S0EswWrV/lib/python3.8/site-packages/jedi/inference/references.py", line 150, in find_references
    new = _dictionarize(_find_names(module_context, name_leaf))
  File "/Users/lryu/.local/share/virtualenvs/python-parser-S0EswWrV/lib/python3.8/site-packages/jedi/inference/references.py", line 75, in _find_names
    found_names = set(name.goto())
  File "/Users/lryu/.local/share/virtualenvs/python-parser-S0EswWrV/lib/python3.8/site-packages/jedi/inference/names.py", line 155, in goto
    module_names = goto_import(context, name)
  File "/Users/lryu/.local/share/virtualenvs/python-parser-S0EswWrV/lib/python3.8/site-packages/jedi/inference/cache.py", line 44, in wrapper
    rv = function(obj, *args, **kwargs)
  File "/Users/lryu/.local/share/virtualenvs/python-parser-S0EswWrV/lib/python3.8/site-packages/jedi/inference/imports.py", line 77, in goto_import
    _prepare_infer_import(module_context, tree_name)
  File "/Users/lryu/.local/share/virtualenvs/python-parser-S0EswWrV/lib/python3.8/site-packages/jedi/inference/imports.py", line 115, in _prepare_infer_import
    importer = Importer(module_context.inference_state, tuple(import_path),
  File "/Users/lryu/.local/share/virtualenvs/python-parser-S0EswWrV/lib/python3.8/site-packages/jedi/inference/imports.py", line 177, in __init__
    base = module_context.get_value().py__package__()
  File "/Users/lryu/.local/share/virtualenvs/python-parser-S0EswWrV/lib/python3.8/site-packages/jedi/inference/value/module.py", line 186, in py__package__
    return self.string_names[:-1]
```