### PR TITLE
Allow tweaking Interpreter sys_path

### DIFF
--- a/jedi/api/__init__.py
+++ b/jedi/api/__init__.py
@@ -719,12 +719,12 @@ class Interpreter(Script):
         else:
             if not isinstance(environment, InterpreterEnvironment):
                 raise TypeError("The environment needs to be an InterpreterEnvironment subclass.")
-        
+
         if project is None:
             project = Project(Path.cwd())
 
         super().__init__(code, environment=environment, project=project, **kwds)
-            
+
         self.namespaces = namespaces
         self._inference_state.allow_descriptor_getattr = self._allow_descriptor_getattr_default
 

--- a/jedi/api/__init__.py
+++ b/jedi/api/__init__.py
@@ -707,7 +707,7 @@ class Interpreter(Script):
     """
     _allow_descriptor_getattr_default = True
 
-    def __init__(self, code, namespaces, **kwds):
+    def __init__(self, code, namespaces, *, project=None, **kwds):
         try:
             namespaces = [dict(n) for n in namespaces]
         except Exception:
@@ -719,12 +719,11 @@ class Interpreter(Script):
         else:
             if not isinstance(environment, InterpreterEnvironment):
                 raise TypeError("The environment needs to be an InterpreterEnvironment subclass.")
+        
+        if project is None:
+            project = Project(Path.cwd())
 
-        if "project" in kwds:
-            super().__init__(code, environment=environment, **kwds)
-        else:
-            super().__init__(code, environment=environment,
-                             project=Project(Path.cwd()), **kwds)
+        super().__init__(code, environment=environment, project=project, **kwds)
             
         self.namespaces = namespaces
         self._inference_state.allow_descriptor_getattr = self._allow_descriptor_getattr_default

--- a/jedi/api/__init__.py
+++ b/jedi/api/__init__.py
@@ -720,8 +720,12 @@ class Interpreter(Script):
             if not isinstance(environment, InterpreterEnvironment):
                 raise TypeError("The environment needs to be an InterpreterEnvironment subclass.")
 
-        super().__init__(code, environment=environment,
-                         project=Project(Path.cwd()), **kwds)
+        if "project" in kwds:
+            super().__init__(code, environment=environment, **kwds)
+        else:
+            super().__init__(code, environment=environment,
+                             project=Project(Path.cwd()), **kwds)
+            
         self.namespaces = namespaces
         self._inference_state.allow_descriptor_getattr = self._allow_descriptor_getattr_default
 


### PR DESCRIPTION
Currently it is not easy to tweak `Interpreter`'s  sys_path. It is not clear how to make `InterpreterEnvironment` and giving a `project` argument gives duplicate named argument error.

I must say I liked the pre-0.18 approach better (with explicit `sys_path` parameter). I understand that the new approach is meant to be cleaner for common cases, but I'm trying to offer autocompletion for a MicroPython interpreter using module stubs in a directory unrelated to any CPython interpreter.

With the changes proposed in this PR I seem to be able to achieve my goal. I wouldn't mind the custom `InterpreterEnvironment` approach either, but I didn't understand how to make one and what else to take into account with this approach. If you added an API for making an `InterpreterEnvironment` with extra sys_path directories, then I would like this even more.