### PR TITLE
Signature inference for attributes inherited from generic dataclasses

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -62,6 +62,7 @@ Code Contributors
 - Andrii Kolomoiets (@muffinmad)
 - Leo Ryu (@Leo-Ryu)
 - Joseph Birkner (@josephbirkner)
+- Brent Yi (@brentyi)
 
 And a few more "anonymous" contributors.
 

--- a/jedi/plugins/stdlib.py
+++ b/jedi/plugins/stdlib.py
@@ -24,6 +24,7 @@ from jedi.inference.value.instance import \
     AnonymousMethodExecutionContext, MethodExecutionContext
 from jedi.inference.base_value import ContextualizedNode, \
     NO_VALUES, ValueSet, ValueWrapper, LazyValueWrapper
+from jedi.inference.gradual.base import GenericClass
 from jedi.inference.value import ClassValue, ModuleValue
 from jedi.inference.value.klass import ClassMixin
 from jedi.inference.value.function import FunctionMixin
@@ -603,7 +604,13 @@ class DataclassWrapper(ValueWrapper, ClassMixin):
     def get_signatures(self):
         param_names = []
         for cls in reversed(list(self.py__mro__())):
-            if isinstance(cls, DataclassWrapper):
+            if (
+                isinstance(cls, DataclassWrapper)
+                or (
+                    isinstance(cls, GenericClass)
+                    and isinstance(cls._get_wrapped_value(), DataclassWrapper)
+                )
+            ):
                 filter_ = cls.as_context().get_global_filter()
                 # .values ordering is not guaranteed, at least not in
                 # Python < 3.6, when dicts where not ordered, which is an

--- a/test/test_inference/test_signature.py
+++ b/test/test_inference/test_signature.py
@@ -315,6 +315,15 @@ def test_wraps_signature(Script, code, signature):
              z = 5
          @dataclass
          class X(Y):'''), ['y']],
+        [dedent('''
+         from typing import Generic, TypeVar
+         T = TypeVar("T")
+         @dataclass
+         class Y(Generic[T]):
+             y: T
+             z = 5
+         @dataclass
+         class X(Y[int]):'''), ['y']],
     ]
 )
 def test_dataclass_signature(Script, skip_pre_python37, start, start_params):


### PR DESCRIPTION
Thanks for the great library!

Just patched an issue where dataclasses that also happen to be generics aren't being recognized when climbing the MRO. See example in test file.