### PR TITLE
Fix module-scope passthrough function signatures

### DIFF
--- a/jedi/inference/star_args.py
+++ b/jedi/inference/star_args.py
@@ -22,7 +22,15 @@ def _iter_nodes_for_param(param_name):
     from jedi.inference.arguments import TreeArguments
 
     execution_context = param_name.parent_context
-    function_node = execution_context.tree_node
+    # Walk up the parso tree to get the FunctionNode we want. We use the parso
+    # tree rather than going via the execution context so that we're agnostic of
+    # the specific scope we're evaluating within (i.e: module or function,
+    # etc.).
+    # - .tree_name is a Name
+    # - .parent is a Param
+    # - .parent is a PythonNode(parameters)
+    # - .parent is the FunctionNode we want.
+    function_node = param_name.tree_name.parent.parent.parent
     module_node = function_node.get_root_node()
     start = function_node.children[-1].start_pos
     end = function_node.children[-1].end_pos

--- a/jedi/inference/star_args.py
+++ b/jedi/inference/star_args.py
@@ -12,6 +12,8 @@ The signature here for bar should be `bar(b, c)` instead of bar(*args).
 """
 from inspect import Parameter
 
+from parso import tree
+
 from jedi.inference.utils import to_list
 from jedi.inference.names import ParamNameWrapper
 from jedi.inference.helpers import is_big_annoying_library
@@ -26,11 +28,7 @@ def _iter_nodes_for_param(param_name):
     # tree rather than going via the execution context so that we're agnostic of
     # the specific scope we're evaluating within (i.e: module or function,
     # etc.).
-    # - .tree_name is a Name
-    # - .parent is a Param
-    # - .parent is a PythonNode(parameters)
-    # - .parent is the FunctionNode we want.
-    function_node = param_name.tree_name.parent.parent.parent
+    function_node = tree.search_ancestor(param_name.tree_name, 'funcdef', 'lambdef')
     module_node = function_node.get_root_node()
     start = function_node.children[-1].start_pos
     end = function_node.children[-1].end_pos

--- a/test/test_inference/test_signature.py
+++ b/test/test_inference/test_signature.py
@@ -292,6 +292,26 @@ def test_pow_signature(Script, environment):
                 return wrapper
 
             x(f)('''), 'f()'],
+        [dedent('''
+            # identifier:C
+            import functools
+            def f(x: int, y: float):
+                pass
+
+            @functools.wraps(f)
+            def wrapper(*args, **kwargs):
+                return f(*args, **kwargs)
+
+            wrapper('''), 'f(x: int, y: float)'],
+        [dedent('''
+            # identifier:D
+            def f(x: int, y: float):
+                pass
+
+            def wrapper(*args, **kwargs):
+                return f(*args, **kwargs)
+
+            wrapper('''), 'wrapper(x: int, y: float)'],
     ]
 )
 def test_wraps_signature(Script, code, signature):

--- a/test/test_inference/test_signature.py
+++ b/test/test_inference/test_signature.py
@@ -273,8 +273,6 @@ def test_pow_signature(Script, environment):
             def x(f):
                 @functools.wraps(f)
                 def wrapper(*args):
-                    # Have no arguments here, but because of wraps, the signature
-                    # should still be f's.
                     return f(*args)
                 return wrapper
 

--- a/test/test_inference/test_signature.py
+++ b/test/test_inference/test_signature.py
@@ -267,6 +267,7 @@ def test_pow_signature(Script, environment):
 @pytest.mark.parametrize(
     'code, signature', [
         [dedent('''
+            # identifier:A
             import functools
             def f(x):
                 pass
@@ -278,6 +279,7 @@ def test_pow_signature(Script, environment):
 
             x(f)('''), 'f(x, /)'],
         [dedent('''
+            # identifier:B
             import functools
             def f(x):
                 pass


### PR DESCRIPTION
This ensures `*args, **kwargs` lookthrough works at module scope as well as at function scope, meaning that passthrough signatures will be found for top level functions.

Fixes https://github.com/davidhalter/jedi/issues/1791.