### PR TITLE
Improve completion for pytest fixtures

### DIFF
--- a/jedi/inference/value/function.py
+++ b/jedi/inference/value/function.py
@@ -344,7 +344,8 @@ class BaseFunctionExecutionContext(ValueContext, TreeContextMixin):
                     GenericClass(c, TupleGenericManager(generics)) for c in async_classes
                 ).execute_annotation()
         else:
-            if self.is_generator():
+            # If there are annotations, prefer them over anything else.
+            if self.is_generator() and not self.infer_annotations():
                 return ValueSet([iterable.Generator(inference_state, self)])
             else:
                 return self.get_return_values()

--- a/jedi/plugins/pytest.py
+++ b/jedi/plugins/pytest.py
@@ -43,6 +43,9 @@ def infer_anonymous_param(func):
             return function_context.get_return_values()
 
     def wrapper(param_name):
+        # parameters with an annotation do not need special handling
+        if param_name.annotation_node:
+            return func(param_name)
         is_pytest_param, param_name_is_function_name = \
             _is_a_pytest_param_and_inherited(param_name)
         if is_pytest_param:

--- a/test/completion/generators.py
+++ b/test/completion/generators.py
@@ -309,3 +309,8 @@ def annotation2() -> Iterator[float]:
 next(annotation1())
 #? float()
 next(annotation2())
+
+
+# annotations should override generator inference
+#? float()
+annotation1()

--- a/test/completion/pytest.py
+++ b/test/completion/pytest.py
@@ -64,6 +64,11 @@ def lala(my_fixture):
 def lala(my_fixture):
     pass
 
+# overriding types of a fixture should be possible
+def test_x(my_yield_fixture: str):
+    #? str()
+    my_yield_fixture
+
 # -----------------
 # completion
 # -----------------


### PR DESCRIPTION
In the following code jedi would provide completions (see last line) for a generator object. But pytest will return the object "A" in the fixture not a generator. 
So I reordered the jedi code to first check if jedi has to handle a pytest generator here.

```python
import pytest


class A():
    def my_test(self):
        pass


@pytest.fixture
def my_a() -> A:
    yield A()


def test_a(my_a: A):
    my_a.
```