### PR TITLE
fix(import): support for nested namespace packages

### DIFF
--- a/jedi/inference/imports.py
+++ b/jedi/inference/imports.py
@@ -422,11 +422,9 @@ def import_module(inference_state, import_names, parent_module_value, sys_path):
             # The module might not be a package.
             return NO_VALUES
 
-        for path in paths:
-            # At the moment we are only using one path. So this is
-            # not important to be correct.
+        for i, path in enumerate(paths):
             if not isinstance(path, list):
-                path = [path]
+                path = paths[i:]
             file_io_or_ns, is_pkg = inference_state.compiled_subprocess.get_module_info(
                 string=import_names[-1],
                 path=path,

--- a/test/completion/namespace1/pkg1/pkg2/mod1.py
+++ b/test/completion/namespace1/pkg1/pkg2/mod1.py
@@ -1,0 +1,1 @@
+mod1_name = 'mod1'

--- a/test/completion/namespace2/pkg1/pkg2/mod2.py
+++ b/test/completion/namespace2/pkg1/pkg2/mod2.py
@@ -1,0 +1,1 @@
+mod2_name = 'mod2'

--- a/test/completion/ns_path.py
+++ b/test/completion/ns_path.py
@@ -1,0 +1,18 @@
+import sys
+import os
+from os.path import dirname
+
+sys.path.insert(0, os.path.join(dirname(__file__), 'namespace2'))
+sys.path.insert(0, os.path.join(dirname(__file__), 'namespace1'))
+
+#? ['mod1']
+import pkg1.pkg2.mod1
+
+#? ['mod2']
+import pkg1.pkg2.mod2
+
+#? ['mod1_name']
+pkg1.pkg2.mod1.mod1_name
+
+#? ['mod2_name']
+pkg1.pkg2.mod2.mod2_name


### PR DESCRIPTION
If multiple directories in sys.path provide a nested namespace package, then jedi would only visit the first directory which
contained the package.  Fix this by saving the remaining path list in the ImplicitNamespaceValue and add a test for it.

Added test namespace packages to demonstrate the failure:

`
namespace1/
namespace1/pkg1
namespace1/pkg1/pkg2
namespace1/pkg1/pkg2/mod1.py
namespace2
namespace2/pkg1
namespace2/pkg1/pkg2
namespace2/pkg1/pkg2/mod2.py
`

If both namespace1 and namespace2 are added to sys path, then jedi sees only mod1 without the fix.  After the fix it correctly sees both mod1 and mod2.
