### PR TITLE
Adds support for "async with" via #1818

### DIFF
--- a/jedi/inference/syntax_tree.py
+++ b/jedi/inference/syntax_tree.py
@@ -738,6 +738,13 @@ def tree_name_to_values(inference_state, context, tree_name):
         types = infer_expr_stmt(context, node, tree_name)
     elif typ == 'with_stmt':
         value_managers = context.infer_node(node.get_test_node_from_name(tree_name))
+        if node.parent.type == 'async_stmt':
+            # In the case of `async with` statements, we need to
+            # first get the coroutine from the `__aenter__` method,
+            # then "unwrap" via the `__await__` method
+            enter_methods = value_managers.py__getattribute__('__aenter__')
+            coro = enter_methods.execute_with_values()
+            return coro.py__await__().py__stop_iteration_returns()
         enter_methods = value_managers.py__getattribute__('__enter__')
         return enter_methods.execute_with_values()
     elif typ in ('import_from', 'import_name'):

--- a/test/completion/async_.py
+++ b/test/completion/async_.py
@@ -105,3 +105,22 @@ async def f():
     f = await C().async_for_classmethod()
     #? C()
     f
+
+
+class AsyncCtxMgr:
+    def some_method():
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        pass
+
+
+async def asyncctxmgr():
+    async with AsyncCtxMgr() as acm:
+        #? AsyncCtxMgr()
+        acm
+        #? ['some_method']
+        acm.som

--- a/test/completion/async_.py
+++ b/test/completion/async_.py
@@ -26,11 +26,6 @@ async def y():
     x().__await__().__next
     return 2
 
-async def x2():
-    async with open('asdf') as f:
-        #? ['readlines']
-        f.readlines
-
 class A():
     @staticmethod
     async def b(c=1, d=2):


### PR DESCRIPTION
Per the discussion in #1818, this implements basic support for return values from `__aenter__` on async context managers. To test, I've added both a previously-failing inference and completion integration tests that are now passing with this patch. Also a simple test in my IDE confirms that completions are now showing up for the following code example:

```python
class Thing:
    def get_num(self) -> int:
        return 10


class AsyncOtherThing:
    def __init__(self, thing: Thing):
        self.thing = thing

    async def __aenter__(self) -> Thing:
        return self.thing

    async def __aexit__(self, exc_type, value, traceback):
        pass


async def async_test():
    async with AsyncOtherThing(Thing()) as th:
        th.  # Shows `get_num()` and other internal attributes of `Thing`
```

Thanks @davidhalter for the help!