### PR TITLE
Make typed decorators work for instance methods

### DIFF
--- a/jedi/inference/gradual/typing.py
+++ b/jedi/inference/gradual/typing.py
@@ -294,6 +294,9 @@ class Callable(BaseTypingInstance):
             from jedi.inference.gradual.annotation import infer_return_for_callable
             return infer_return_for_callable(arguments, param_values, result_values)
 
+    def py__get__(self, instance, class_value):
+        return ValueSet([self])
+
 
 class Tuple(BaseTypingInstance):
     def _is_homogenous(self):

--- a/test/completion/lambdas.py
+++ b/test/completion/lambdas.py
@@ -110,4 +110,4 @@ class Test(object):
 # nocond lambdas make no sense at all.
 
 #? int()
-[a for a in [1,2] if lambda: 3][0]
+[a for a in [1,2] if (lambda: 3)][0]

--- a/test/completion/pep0484_decorators.py
+++ b/test/completion/pep0484_decorators.py
@@ -1,0 +1,50 @@
+""" Pep-0484 type hinted decorators """
+
+from typing import Callable
+
+
+def decorator(func):
+    def wrapper(*a, **k):
+        return str(func(*a, **k))
+    return wrapper
+
+
+def typed_decorator(func: Callable[..., int]) -> Callable[..., str]:
+    ...
+
+# Functions
+
+@decorator
+def plain_func() -> int:
+    return 4
+
+#? str()
+plain_func()
+
+
+@typed_decorator
+def typed_func() -> int:
+    return 4
+
+#? str()
+typed_func()
+
+
+# Methods
+
+class X:
+    @decorator
+    def plain_method(self) -> int:
+        return 4
+
+    @typed_decorator
+    def typed_method(self) -> int:
+        return 4
+
+inst = X()
+
+#? str()
+inst.plain_method()
+
+#? str()
+inst.typed_method()


### PR DESCRIPTION
This feels incomplete when compared to `FunctionMixin.py__get__`, however seems to work at least in the cut-down reported.

I've also manually checked that this fixes the more complete version (i.e: with `contextmanager`).

Fixes https://github.com/davidhalter/jedi/issues/1801.