### PR TITLE
docs: Fix a few typos

### DIFF
--- a/jedi/api/exceptions.py
+++ b/jedi/api/exceptions.py
@@ -23,7 +23,7 @@ class RefactoringError(_JediError):
     Refactorings can fail for various reasons. So if you work with refactorings
     like :meth:`.Script.rename`, :meth:`.Script.inline`,
     :meth:`.Script.extract_variable` and :meth:`.Script.extract_function`, make
-    sure to catch these. The descriptions in the errors are ususally valuable
+    sure to catch these. The descriptions in the errors are usually valuable
     for end users.
 
     A typical ``RefactoringError`` would tell the user that inlining is not

--- a/jedi/inference/base_value.py
+++ b/jedi/inference/base_value.py
@@ -297,7 +297,7 @@ class Value(HelperValueMixin):
             just the `_T` generic parameter.
 
         `value_set`: represents the actual argument passed to the parameter
-            we're inferrined for, or (for recursive calls) their types. In the
+            we're inferred for, or (for recursive calls) their types. In the
             above example this would first be the representation of the list
             `[1]` and then, when recursing, just of `1`.
         """

--- a/jedi/inference/compiled/mixed.py
+++ b/jedi/inference/compiled/mixed.py
@@ -34,7 +34,7 @@ class MixedObject(ValueWrapper):
 
     This combined logic makes it possible to provide more powerful REPL
     completion. It allows side effects that are not noticable with the default
-    parser structure to still be completeable.
+    parser structure to still be completable.
 
     The biggest difference from CompiledValue to MixedObject is that we are
     generally dealing with Python code and not with C code. This will generate
@@ -267,7 +267,7 @@ def _find_syntax_node_name(inference_state, python_object):
 @inference_state_function_cache()
 def _create(inference_state, compiled_value, module_context):
     # TODO accessing this is bad, but it probably doesn't matter that much,
-    # because we're working with interpreteters only here.
+    # because we're working with interpreters only here.
     python_object = compiled_value.access_handle.access._obj
     result = _find_syntax_node_name(inference_state, python_object)
     if result is None:

--- a/jedi/inference/value/dynamic_arrays.py
+++ b/jedi/inference/value/dynamic_arrays.py
@@ -16,7 +16,7 @@ settings will stop this process.
 
 It is important to note that:
 
-1. Array modfications work only in the current module.
+1. Array modifications work only in the current module.
 2. Jedi only checks Array additions; ``list.pop``, etc are ignored.
 """
 from jedi import debug


### PR DESCRIPTION
There are small typos in:
- jedi/api/exceptions.py
- jedi/inference/base_value.py
- jedi/inference/compiled/mixed.py
- jedi/inference/value/dynamic_arrays.py

Fixes:
- Should read `usually` rather than `ususally`.
- Should read `modifications` rather than `modfications`.
- Should read `interpreters` rather than `interpreteters`.
- Should read `inferred` rather than `inferrined`.
- Should read `completable` rather than `completeable`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md