### PR TITLE
Fix test where home could be a potential project

### DIFF
--- a/test/test_api/test_project.py
+++ b/test/test_api/test_project.py
@@ -178,7 +178,7 @@ def test_is_potential_project(path, expected):
 
     if expected is None:
         try:
-            expected = _CONTAINS_POTENTIAL_PROJECT in os.listdir(path)
+            expected = bool(set(_CONTAINS_POTENTIAL_PROJECT) & set(os.listdir(path)))
         except OSError:
             expected = False
 


### PR DESCRIPTION
The test would fail in an environment where any of the files in
`jedi.api.project._CONTAINS_POTENTIAL_PROJECT` is present at the home directory.
