### PR TITLE
Fix skipped collection of pytest integration test files

### DIFF
--- a/jedi/inference/references.py
+++ b/jedi/inference/references.py
@@ -237,6 +237,7 @@ def recurse_find_python_folders_and_files(folder_io, except_paths=()):
         for folder_io in folder_ios:
             yield folder_io, None
 
+
 def recurse_find_python_files(folder_io, except_paths=()):
     for folder_io, file_io in recurse_find_python_folders_and_files(folder_io, except_paths):
         if file_io is not None:

--- a/test/run.py
+++ b/test/run.py
@@ -209,7 +209,7 @@ class IntegrationTestCase(BaseTestCase):
             TEST_REFERENCES: self.run_get_references,
         }
         if (self.path.endswith('pytest.py') or self.path.endswith('conftest.py')) \
-                and environment.executable != os.path.realpath(sys.executable):
+                and os.path.realpath(environment.executable) != os.path.realpath(sys.executable):
             # It's not guarantueed that pytest is installed in test
             # environments, if we're not running in the same environment that
             # we're already in, so just skip that case.


### PR DESCRIPTION
On integration tests file collection,
the value of `environment.executable` can also be a symlink
(e.g. in a virtualenv) with a different name than,
but pointing to the same as `sys.executable`
(e.g. .../bin/python3.10 and .../bin/python, respectively).

That causes skipping the collection of `completion/pytest.py`
and `completion/conftest.py` a lot of times, depending on the environment.
(e.g. "60 skipped" before x "23 skipped" after, in a local virtualenv)