### PR TITLE
Find external pytest fixtures

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -1,4 +1,4 @@
-﻿Main Authors
+Main Authors
 ------------
 
 - David Halter (@davidhalter) <davidhalter88@gmail.com>
@@ -62,6 +62,7 @@ Code Contributors
 - Andrii Kolomoiets (@muffinmad)
 - Leo Ryu (@Leo-Ryu)
 - Joseph Birkner (@josephbirkner)
+- Márcio Mazza (@marciomazza)
 
 And a few more "anonymous" contributors.
 

--- a/jedi/plugins/pytest.py
+++ b/jedi/plugins/pytest.py
@@ -1,4 +1,3 @@
-from importlib.metadata import entry_points
 from pathlib import Path
 
 from parso.tree import search_ancestor
@@ -138,7 +137,9 @@ def _find_pytest_plugin_modules():
 
     See https://docs.pytest.org/en/stable/how-to/writing_plugins.html#setuptools-entry-points
     """
-    return [ep.value.split(".") for ep in entry_points(group="pytest11")]
+    from pkg_resources import iter_entry_points
+
+    return [ep.module_name.split(".") for ep in iter_entry_points(group="pytest11")]
 
 
 @inference_state_method_cache()

--- a/jedi/plugins/pytest.py
+++ b/jedi/plugins/pytest.py
@@ -1,4 +1,4 @@
-import importlib.metadata
+from importlib.metadata import entry_points
 from pathlib import Path
 
 from parso.tree import search_ancestor
@@ -138,13 +138,7 @@ def _find_pytest_plugin_modules():
 
     See https://docs.pytest.org/en/stable/how-to/writing_plugins.html#setuptools-entry-points
     """
-    entry_points = (
-        ep
-        for dist in importlib.metadata.distributions()
-        for ep in dist.entry_points
-        if ep.group == "pytest11"
-    )
-    return [ep.value.split(".") for ep in entry_points]
+    return [ep.value.split(".") for ep in entry_points(group="pytest11")]
 
 
 @inference_state_method_cache()

--- a/jedi/plugins/pytest.py
+++ b/jedi/plugins/pytest.py
@@ -186,9 +186,12 @@ class FixtureFilter(ParserTreeFilter):
             # resolve possible imports before checking for a fixture
             if name.parent.type == "import_from":
                 imported_names = goto_import(self.parent_context, name)
+                # discard imports of whole modules, that have no tree_name
+                imported_tree_names = (
+                    iname.tree_name for iname in imported_names if iname.tree_name
+                )
                 if any(
-                    self._is_fixture(imported_name.tree_name)
-                    for imported_name in imported_names
+                    self._is_fixture(tree_name) for tree_name in imported_tree_names
                 ):
                     yield name
             elif self._is_fixture(name):

--- a/test/completion/pytest.py
+++ b/test/completion/pytest.py
@@ -183,3 +183,28 @@ def with_annot() -> Generator[float, None, None]:
 def test_with_annot(inheritance_fixture, with_annot):
     #? float()
     with_annot
+
+# -----------------
+# pytest external plugins
+# -----------------
+
+#? ['admin_user', 'admin_client']
+def test_z(admin
+
+#! 15 ['def admin_client']
+def test_p(admin_client):
+    #? ['login', 'logout']
+    admin_client.log
+
+@pytest.fixture
+@some_decorator
+#? ['admin_user']
+def bla(admin_u
+    return
+
+@pytest.fixture
+@some_decorator
+#! 12 ['def admin_user']
+def bla(admin_user):
+    pass
+

--- a/test/examples/pytest_plugin_package/pytest_plugin/fixtures.py
+++ b/test/examples/pytest_plugin_package/pytest_plugin/fixtures.py
@@ -1,0 +1,6 @@
+from pytest import fixture
+
+
+@fixture()
+def admin_user():
+    pass

--- a/test/examples/pytest_plugin_package/pytest_plugin/plugin.py
+++ b/test/examples/pytest_plugin_package/pytest_plugin/plugin.py
@@ -1,0 +1,18 @@
+import pytest
+from pytest import fixture
+
+
+from pytest_plugin.fixtures import admin_user  # noqa
+
+
+class Client:
+    def login(self, **credentials):
+        ...
+
+    def logout(self):
+        ...
+
+
+@pytest.fixture()
+def admin_client():
+    return Client()

--- a/test/examples/pytest_plugin_package/pytest_plugin/plugin.py
+++ b/test/examples/pytest_plugin_package/pytest_plugin/plugin.py
@@ -1,8 +1,11 @@
 import pytest
-from pytest import fixture
+
+from .fixtures import admin_user  # noqa
 
 
-from pytest_plugin.fixtures import admin_user  # noqa
+@pytest.fixture()
+def admin_client():
+    return Client()
 
 
 class Client:
@@ -11,8 +14,3 @@ class Client:
 
     def logout(self):
         ...
-
-
-@pytest.fixture()
-def admin_client():
-    return Client()

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -1,4 +1,5 @@
 import os
+from collections import namedtuple
 
 import pytest
 
@@ -42,6 +43,22 @@ def test_completion(case, monkeypatch, environment, has_django):
 
     if (not has_django) and case.path.endswith('django.py'):
         pytest.skip('Needs django to be installed to run this test.')
+
+    if case.path.endswith("pytest.py"):
+        # to test finding pytest fixtures from external plugins
+        # add a stub pytest plugin to the project sys_path...
+        pytest_plugin_dir = str(helpers.get_example_dir("pytest_plugin_package"))
+        case._project.added_sys_path = [pytest_plugin_dir]
+
+        # ... and mock setuptools entry points to include it
+        # see https://docs.pytest.org/en/stable/how-to/writing_plugins.html#setuptools-entry-points
+        def mock_entry_points(group):
+            assert group == "pytest11"
+            EntryPoint = namedtuple("EntryPoint", ["value"])
+            return [EntryPoint(value="pytest_plugin.plugin")]
+
+        monkeypatch.setattr("jedi.plugins.pytest.entry_points", mock_entry_points)
+
     repo_root = helpers.root_dir
     monkeypatch.chdir(os.path.join(repo_root, 'jedi'))
     case.run(assert_case_equal, environment)

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -52,12 +52,12 @@ def test_completion(case, monkeypatch, environment, has_django):
 
         # ... and mock setuptools entry points to include it
         # see https://docs.pytest.org/en/stable/how-to/writing_plugins.html#setuptools-entry-points
-        def mock_entry_points(group):
+        def mock_iter_entry_points(group):
             assert group == "pytest11"
-            EntryPoint = namedtuple("EntryPoint", ["value"])
-            return [EntryPoint(value="pytest_plugin.plugin")]
+            EntryPoint = namedtuple("EntryPoint", ["module_name"])
+            return [EntryPoint("pytest_plugin.plugin")]
 
-        monkeypatch.setattr("jedi.plugins.pytest.entry_points", mock_entry_points)
+        monkeypatch.setattr("pkg_resources.iter_entry_points", mock_iter_entry_points)
 
     repo_root = helpers.root_dir
     monkeypatch.chdir(os.path.join(repo_root, 'jedi'))


### PR DESCRIPTION
Find `pytest` fixtures from external plugins registered via `setuptools` entry points.

Using `setuptools` entry points is probably the main `pytest` mechanism of plugin discovery.

See https://docs.pytest.org/en/stable/how-to/writing_plugins.html#setuptools-entry-points

Some examples of pytest plugins installed like this are `pytest-django`, `pytest-sugar` and `Faker`.

This extends the functionality of #791
and maybe eliminates the need for #1786.
