### PR TITLE
python3.11 compatibility

### DIFF
--- a/jedi/inference/compiled/subprocess/functions.py
+++ b/jedi/inference/compiled/subprocess/functions.py
@@ -151,7 +151,11 @@ def _find_module(string, path=None, full_name=None, is_global_search=True):
 
         spec = find_spec(string, p)
         if spec is not None:
+            if spec.origin == "frozen":
+                continue
+
             loader = spec.loader
+
             if loader is None and not spec.has_location:
                 # This is a namespace package.
                 full_name = string if not path else full_name


### PR DESCRIPTION
Python3.11 introduces "[frozen imports](https://docs.python.org/3.11/whatsnew/3.11.html#faster-startup)" for core modules. This causes the tests to fail because we import the frozen module and then can't get the properties we expect to get from it. This small patch causes jedi to skip the frozen module, which repairs most of the test suite. Instead of 15 failures we now have 5, of which 3 also fail for me with python3.10.

python3.10:
```
=========================================================================== short test summary info ============================================================================
FAILED test/test_integration.py::test_completion[pytest:142] - AssertionError:
FAILED test/test_integration.py::test_completion[conftest:27] - AssertionError:
FAILED test/test_inference/test_imports.py::test_os_issues - AssertionError: assert 'path' not in ['abc', 'aifc', 'alabaster', 'antigravity', 'anyio', 'appdirs', ...]
================================================ 3 failed, 3749 passed, 94 skipped, 5 xfailed, 10 warnings in 153.98s (0:02:33) ================================================
```

python3.11, after change:
```
=================================================================================================== short test summary info ===================================================================================================
FAILED test/test_integration.py::test_completion[pytest:142] - AssertionError:
FAILED test/test_integration.py::test_completion[conftest:27] - AssertionError:
FAILED test/test_api/test_interpreter.py::test_string_annotation[annotations10-result10-] - AssertionError: assert ['str'] == []
FAILED test/test_api/test_interpreter.py::test_string_annotation[annotations13-result13-] - AssertionError: assert ['_AnyMeta'] == []
FAILED test/test_inference/test_imports.py::test_os_issues - AssertionError: assert 'path' not in ['abc', 'aifc', 'alabaster', 'antigravity', 'anyio', 'appdirs', ...]
======================================================================= 5 failed, 3747 passed, 94 skipped, 5 xfailed, 10 warnings in 119.89s (0:01:59) ========================================================================
```

Still two more tests that expose some python3.11 incompatibility, I'll see if I can debug those later.

Bug: https://github.com/davidhalter/jedi/issues/1858
Signed-off-by: Andrew Ammerlaan <andrewammerlaan@gentoo.org>