### PR TITLE
Replaced tuple passed as sys_path actual argument with list

### DIFF
--- a/jedi/inference/__init__.py
+++ b/jedi/inference/__init__.py
@@ -125,7 +125,7 @@ class InferenceState:
     @inference_state_function_cache()
     def builtins_module(self):
         module_name = 'builtins'
-        builtins_module, = self.import_module((module_name,), sys_path=())
+        builtins_module, = self.import_module((module_name,), sys_path=[])
         return builtins_module
 
     @property  # type: ignore[misc]


### PR DESCRIPTION
Fixes davidhalter#1909

The sys_path argument is used to temporarily replace the actual sys.path which causes sys.path.insert calls to fail.

This issue can also be fixed by protecting assignments to sys.path by wrapping the rvalue in a list but I am not sure about the implications of that.