### PR TITLE
Update mypy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Run tests
         run: |
           python -m flake8 jedi setup.py
-          python -m mypy jedi sith.py
+          python -m mypy jedi sith.py setup.py
 
   coverage:
     runs-on: ubuntu-20.04

--- a/jedi/api/environment.py
+++ b/jedi/api/environment.py
@@ -15,7 +15,7 @@ from jedi.inference.compiled.subprocess import CompiledSubprocess, \
 
 import parso
 
-_VersionInfo = namedtuple('VersionInfo', 'major minor micro')
+_VersionInfo = namedtuple('VersionInfo', 'major minor micro')  # type: ignore[name-match]
 
 _SUPPORTED_PYTHONS = ['3.10', '3.9', '3.8', '3.7', '3.6']
 _SAFE_PATHS = ['/usr/bin', '/usr/local/bin']
@@ -384,8 +384,7 @@ def _get_executable_path(path, safe=True):
 
 
 def _get_executables_from_windows_registry(version):
-    # https://github.com/python/typeshed/pull/3794 adds winreg
-    import winreg  # type: ignore[import]
+    import winreg
 
     # TODO: support Python Anaconda.
     sub_keys = [

--- a/jedi/api/keywords.py
+++ b/jedi/api/keywords.py
@@ -5,8 +5,7 @@ from typing import Dict, Optional
 from jedi.inference.names import AbstractArbitraryName
 
 try:
-    # https://github.com/python/typeshed/pull/4351 adds pydoc_data
-    from pydoc_data import topics  # type: ignore[import]
+    from pydoc_data import topics
     pydoc_topics: Optional[Dict[str, str]] = topics.topics
 except ImportError:
     # Python 3.6.8 embeddable does not have pydoc_data.

--- a/jedi/inference/compiled/access.py
+++ b/jedi/inference/compiled/access.py
@@ -40,7 +40,7 @@ NOT_CLASS_TYPES = (
 MethodDescriptorType = type(str.replace)
 WrapperDescriptorType = type(set.__iter__)
 # `object.__subclasshook__` is an already executed descriptor.
-object_class_dict = type.__dict__["__dict__"].__get__(object)
+object_class_dict = type.__dict__["__dict__"].__get__(object)  # type: ignore[index]
 ClassMethodDescriptorType = type(object_class_dict['__subclasshook__'])
 
 _sentinel = object()

--- a/jedi/utils.py
+++ b/jedi/utils.py
@@ -2,7 +2,7 @@
 Utilities for end-users.
 """
 
-import __main__  # type: ignore[import]
+import __main__
 from collections import namedtuple
 import logging
 import traceback

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,9 @@ max-line-length = 100
 # Exclude our copies of external stubs
 exclude = ^jedi/third_party
 
+show_error_codes = true
+enable_error_code = ignore-without-code
+
 # Ensure generics are explicit about what they are (e.g: `List[str]` rather than
 # just `List`)
 disallow_any_generics = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,9 @@ max-line-length = 100
 
 
 [mypy]
+# Exclude our copies of external stubs
+exclude = ^jedi/third_party
+
 # Ensure generics are explicit about what they are (e.g: `List[str]` rather than
 # just `List`)
 disallow_any_generics = True

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,10 @@ setup(name='jedi',
           ],
           'qa': [
               'flake8==3.8.3',
-              'mypy==0.782',
+              # latest version supporting Python 3.6
+              'mypy==0.971',
+              # Arbitrary pins, latest at the time of pinning
+              'types-setuptools==67.2.0.1',
           ],
           'docs': [
               # Just pin all of these.


### PR DESCRIPTION
This includes updating the ignore comments for things which mypy now knows about or now complains about, as well as pulling in some typeshed packages for things outside the standard library.

There's also a small amount of added strictness here now it's possible to add it.

This PR should unblock getting CI for Python 3.11 since the latest version of `mypy` supports a version of `typed-ast` which compatible with 3.11.