### PR TITLE
Support Python 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, windows-2019]
-        python-version: ["3.10", "3.9", "3.8", "3.7", "3.6"]
-        environment: ['3.8', '3.10', '3.9', '3.7', '3.6', 'interpreter']
+        python-version: ["3.11", "3.10", "3.9", "3.8", "3.7", "3.6"]
+        environment: ['3.8', '3.11', '3.10', '3.9', '3.7', '3.6', 'interpreter']
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/jedi/api/environment.py
+++ b/jedi/api/environment.py
@@ -17,7 +17,7 @@ import parso
 
 _VersionInfo = namedtuple('VersionInfo', 'major minor micro')  # type: ignore[name-match]
 
-_SUPPORTED_PYTHONS = ['3.10', '3.9', '3.8', '3.7', '3.6']
+_SUPPORTED_PYTHONS = ['3.11', '3.10', '3.9', '3.8', '3.7', '3.6']
 _SAFE_PATHS = ['/usr/bin', '/usr/local/bin']
 _CONDA_VAR = 'CONDA_PREFIX'
 _CURRENT_VERSION = '%s.%s' % (sys.version_info.major, sys.version_info.minor)

--- a/jedi/inference/__init__.py
+++ b/jedi/inference/__init__.py
@@ -90,7 +90,7 @@ class InferenceState:
         self.compiled_subprocess = environment.get_inference_state_subprocess(self)
         self.grammar = environment.get_grammar()
 
-        self.latest_grammar = parso.load_grammar(version='3.10')
+        self.latest_grammar = parso.load_grammar(version='3.11')
         self.memoize_cache = {}  # for memoize decorators
         self.module_cache = imports.ModuleCache()  # does the job of `sys.modules`.
         self.stub_module_cache = {}  # Dict[Tuple[str, ...], Optional[ModuleValue]]

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,8 @@ setup(name='jedi',
       long_description=readme,
       packages=find_packages(exclude=['test', 'test.*']),
       python_requires='>=3.6',
-      install_requires=['parso>=0.8.0,<0.9.0'],
+      # Python 3.11 grammar is added to parso in 0.8.3
+      install_requires=['parso>=0.8.3,<0.9.0'],
       extras_require={
           'testing': [
               'pytest<7.0.0',
@@ -95,6 +96,7 @@ setup(name='jedi',
           'Programming Language :: Python :: 3.8',
           'Programming Language :: Python :: 3.9',
           'Programming Language :: Python :: 3.10',
+          'Programming Language :: Python :: 3.11',
           'Topic :: Software Development :: Libraries :: Python Modules',
           'Topic :: Text Editors :: Integrated Development Environments (IDE)',
           'Topic :: Utilities',

--- a/test/test_inference/test_sys_path.py
+++ b/test/test_inference/test_sys_path.py
@@ -30,14 +30,16 @@ def test_paths_from_assignment(Script):
     assert paths('sys.path, other = ["a"], 2') == set()
 
 
-def test_venv_and_pths(venv_path):
+def test_venv_and_pths(venv_path, environment):
     pjoin = os.path.join
 
-    site_pkg_path = pjoin(venv_path, 'lib')
     if os.name == 'nt':
-        site_pkg_path = pjoin(site_pkg_path, 'site-packages')
+        if environment.version_info < (3, 11):
+            site_pkg_path = pjoin(venv_path, 'lib', 'site-packages')
+        else:
+            site_pkg_path = pjoin(venv_path, 'Lib', 'site-packages')
     else:
-        site_pkg_path = glob(pjoin(site_pkg_path, 'python*', 'site-packages'))[0]
+        site_pkg_path = glob(pjoin(venv_path, 'lib', 'python*', 'site-packages'))[0]
     shutil.rmtree(site_pkg_path)
     shutil.copytree(get_example_dir('sample_venvs', 'pth_directory'), site_pkg_path)
 


### PR DESCRIPTION
This adds support for targetting Python 3.11 via picking up the latest grammar from `parso` (added in 0.8.3) while also validating support for running on 3.11 by adding it to the CI matrix.

Fixes https://github.com/davidhalter/jedi/issues/1914