### PR TITLE
guard autocomplete of property

### DIFF
--- a/jedi/inference/compiled/access.py
+++ b/jedi/inference/compiled/access.py
@@ -363,7 +363,14 @@ class DirectObjectAccess:
             # warnings should not be shown. See also GH #1383.
             with warnings.catch_warnings(record=True):
                 warnings.simplefilter("always")
-                return_obj = getattr(self._obj, name)
+
+                # Make sure we do not evaluate @property methods on autocompelte
+                # taken from https://github.com/python/cpython/pull/27401/commits/54c6d9c455abc6316a27f7ad443a86546af5f706
+                if isinstance(getattr(type(self._obj), name, None), property):
+                    return_obj = getattr(type(self._obj), name)
+                else:
+                    return_obj = getattr(self._obj, name)
+
         except Exception as e:
             if default is _sentinel:
                 if isinstance(e, AttributeError):


### PR DESCRIPTION
guard evaluating `@property` methods, taken from [bpo-44752](https://github.com/python/cpython/pull/27401/commits/54c6d9c455abc6316a27f7ad443a86546af5f706) to fix IPython accessing `type` [here ](https://github.com/ipython/ipython/blob/75ecfe932fc9ca3505efbebc016b046ffc7d0d68/IPython/core/completer.py#L2903)