### PR TITLE
Update GitHub Actions for Node 16 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,16 +11,16 @@ jobs:
         environment: ['3.8', '3.11', '3.10', '3.9', '3.7', '3.6', 'interpreter']
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: recursive
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         if: ${{ matrix.environment != 'interpreter' }}
         with:
           python-version: ${{ matrix.environment }}
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: recursive
 
@@ -53,7 +53,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: recursive
 

--- a/jedi/plugins/stdlib.py
+++ b/jedi/plugins/stdlib.py
@@ -808,9 +808,11 @@ _implemented = {
     # https://www.attrs.org/en/stable/names.html
     'attr': {
         'define': _dataclass,
+        'frozen': _dataclass,
     },
     'attrs': {
         'define': _dataclass,
+        'frozen': _dataclass,
     },
     'os.path': {
         'dirname': _create_string_input_function(os.path.dirname),


### PR DESCRIPTION
Depends on https://github.com/davidhalter/jedi/pull/1935 for clean CI.