### PR TITLE
Teach Jedi that `attrs`' `frozen` decorator also acts like a dataclass

### DIFF
--- a/jedi/plugins/stdlib.py
+++ b/jedi/plugins/stdlib.py
@@ -808,9 +808,11 @@ _implemented = {
     # https://www.attrs.org/en/stable/names.html
     'attr': {
         'define': _dataclass,
+        'frozen': _dataclass,
     },
     'attrs': {
         'define': _dataclass,
+        'frozen': _dataclass,
     },
     'os.path': {
         'dirname': _create_string_input_function(os.path.dirname),


### PR DESCRIPTION
In 23.1.0 (specifically in https://github.com/python-attrs/attrs/commit/46053d703d99a6e7419fd291cbf546340690d69d) the definition of the `frozen` decorator was tweaked slightly, such that its type stub is separate from that for `define`. This means that Jedi needs to be told about it as a separate member.

I've manually checked that this still works with the prior version of `attrs`.

Fixes https://github.com/davidhalter/jedi/issues/1929