### PR TITLE
Modernise importlib usage

### DIFF
--- a/jedi/inference/compiled/subprocess/__main__.py
+++ b/jedi/inference/compiled/subprocess/__main__.py
@@ -21,11 +21,11 @@ class _ExactImporter(MetaPathFinder):
     def __init__(self, path_dct):
         self._path_dct = path_dct
 
-    def find_module(self, fullname, path=None):
+    def find_spec(self, fullname, path=None, target=None):
         if path is None and fullname in self._path_dct:
             p = self._path_dct[fullname]
-            loader = PathFinder.find_module(fullname, path=[p])
-            return loader
+            spec = PathFinder.find_spec(fullname, path=[p], target=target)
+            return spec
         return None
 
 

--- a/jedi/inference/compiled/subprocess/functions.py
+++ b/jedi/inference/compiled/subprocess/functions.py
@@ -2,7 +2,6 @@ import sys
 import os
 import inspect
 import importlib
-import warnings
 from pathlib import Path
 from zipfile import ZipFile
 from zipimport import zipimporter, ZipImportError
@@ -167,17 +166,16 @@ def _find_module(string, path=None, full_name=None, is_global_search=True):
 
 
 def _find_module_py33(string, path=None, loader=None, full_name=None, is_global_search=True):
-    loader = loader or importlib.machinery.PathFinder.find_module(string, path)
+    if not loader:
+        spec = importlib.machinery.PathFinder.find_spec(string, path)
+        if spec is not None:
+            loader = spec.loader
 
     if loader is None and path is None:  # Fallback to find builtins
         try:
-            with warnings.catch_warnings(record=True):
-                # Mute "DeprecationWarning: Use importlib.util.find_spec()
-                # instead." While we should replace that in the future, it's
-                # probably good to wait until we deprecate Python 3.3, since
-                # it was added in Python 3.4 and find_loader hasn't been
-                # removed in 3.6.
-                loader = importlib.find_loader(string)
+            spec = importlib.util.find_spec(string)
+            if spec is not None:
+                loader = spec.loader
         except ValueError as e:
             # See #491. Importlib might raise a ValueError, to avoid this, we
             # just raise an ImportError to fix the issue.


### PR DESCRIPTION
`find_module` is deprecated in all supported version of Python and is slated for removal in the upcoming 3.12. Happily it seems we can move to the related `find_spec` and just hoist the loader from the spec which that returns. (This is mostly what current `find_module` implementations do anyway).

This is relying on code inspection, some guessing around Python import machinery and existing tests. I'm not sure best to validate this manually.