### PR TITLE
Unpin Django in tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(name='jedi',
               'docopt',
               # coloroma for colored debug output
               'colorama',
-              'Django<3.1',  # For now pin this.
+              'Django',
               'attrs',
           ],
           'qa': [


### PR DESCRIPTION
It's not completely clear why this was pinned originally, though at the time Jedi supported Python 2.7 as well as 3.5-3.8, so that may have had something to do with it.

Removing this pin now seems to work in CI and unblocks some issues we're seeing around Python 3.12 (specifically that Django<3.1 implicitly relies on `distutils`, which is no longer available by default, and possibly other issues).