### PR TITLE
fix jedi-core passing sys_path from jediepcserver.py

### DIFF
--- a/jedi/api/__init__.py
+++ b/jedi/api/__init__.py
@@ -97,7 +97,13 @@ class Script:
         references works well, because the right folder is searched. There are
         also ways to modify the sys path and other things.
     """
-    def __init__(self, code=None, *, path=None, environment=None, project=None):
+    def __init__(self, code=None, *, path=None, environment=None, project=None,
+                 sys_path=None):
+        if sys_path is not None:
+            sys_paths = set(sys.path)
+            for spath in sys_path:
+                if spath not in sys_paths:
+                    sys.path.append(spath)
         self._orig_path = path
         if isinstance(path, str):
             path = Path(path)


### PR DESCRIPTION
The [Emacs Jedi](https://github.com/plandes/emacs-jedi) library creates a `jedi.Script` with a `sys_path` parameter.  It appears this was removed in a more recent version.  I have added the parameter to the class initializer and added any non-`None` paths to the Python `sys.path` list.

This fixes pip package versions higher than 0.17.2 for my set, which is:
Emacs: 29.1
Jedi: 0.3.0
Python: 3.11.6
epc: 0.0.5
sexpdata: 1.0.0
