### PR TITLE
Implement added_conftest_path

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -63,6 +63,7 @@ Code Contributors
 - Leo Ryu (@Leo-Ryu)
 - Joseph Birkner (@josephbirkner)
 - Márcio Mazza (@marciomazza)
+- Vasily Kulikov (@segoon)
 
 And a few more "anonymous" contributors.
 

--- a/jedi/api/project.py
+++ b/jedi/api/project.py
@@ -115,6 +115,7 @@ class Project:
         sys_path=None,
         added_sys_path=(),
         smart_sys_path=True,
+        added_conftest_path=(),
     ) -> None:
         """
         :param path: The base path for this project.
@@ -147,6 +148,7 @@ class Project:
         self._smart_sys_path = smart_sys_path
         self._load_unsafe_extensions = load_unsafe_extensions
         self._django = False
+        self._added_conftest_path = added_conftest_path
         # Remap potential pathlib.Path entries
         self.added_sys_path = list(map(str, added_sys_path))
         """The sys path that is going to be added at the end of the """
@@ -173,6 +175,10 @@ class Project:
         additional paths are added.
         """
         return self._smart_sys_path
+
+    @property
+    def conftest_path(self):
+        return self._added_conftest_path
 
     @property
     def load_unsafe_extensions(self):

--- a/test/completion/fixture_module.py
+++ b/test/completion/fixture_module.py
@@ -1,0 +1,6 @@
+# Exists only for completion/pytest.py
+import pytest
+
+@pytest.fixture
+def module_fixture():
+    pass

--- a/test/completion/pytest.py
+++ b/test/completion/pytest.py
@@ -139,6 +139,9 @@ def test_p(monkeypatch):
 #? ['capsysbinary']
 def test_p(capsysbin
 
+#? ['module_fixture']
+def test_p(module_fi
+
 
 def close_parens():
     pass

--- a/test/run.py
+++ b/test/run.py
@@ -178,7 +178,11 @@ class IntegrationTestCase(BaseTestCase):
         self.start = start
         self.line = line
         self.path = path
-        self._project = jedi.Project(test_dir)
+        self._project = jedi.Project(
+            test_dir,
+            added_conftest_path=(
+                os.path.join(test_dir, 'completion/fixture_module.py'),),
+        )
 
     @property
     def module_name(self):

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -50,7 +50,6 @@ def test_completion(case, monkeypatch, environment, has_django):
         # add a stub pytest plugin to the project sys_path...
         pytest_plugin_dir = str(helpers.get_example_dir("pytest_plugin_package"))
         case._project.added_sys_path = [pytest_plugin_dir]
-        case._project.added_conftest_path = []
 
         # ... and mock the entry points to include it
         # see https://docs.pytest.org/en/stable/how-to/writing_plugins.html#setuptools-entry-points

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -50,6 +50,7 @@ def test_completion(case, monkeypatch, environment, has_django):
         # add a stub pytest plugin to the project sys_path...
         pytest_plugin_dir = str(helpers.get_example_dir("pytest_plugin_package"))
         case._project.added_sys_path = [pytest_plugin_dir]
+        case._project.added_conftest_path = []
 
         # ... and mock the entry points to include it
         # see https://docs.pytest.org/en/stable/how-to/writing_plugins.html#setuptools-entry-points


### PR DESCRIPTION
Add an argument for extra conftest files paths. It is used in specific environments where fixtures are collected through nonstandard way, e.g. in Yandex monorepository Arcadia. One may define a list of extra conftest.py files and use fixtures from there.

Also one can define pytest plugins in 'pytest_plugins' local variable and expect fixtures from the imported plugins to be accessible via jedi.