### PR TITLE
properties with setters are now reported as 'property' for completion

### DIFF
--- a/jedi/parser_utils.py
+++ b/jedi/parser_utils.py
@@ -339,10 +339,10 @@ def _function_is_x_method(decorator_checker):
 function_is_staticmethod = _function_is_x_method(lambda m: m == "staticmethod")
 function_is_classmethod = _function_is_x_method(lambda m: m == "classmethod")
 function_is_property = _function_is_x_method(
-    lambda m: m == "property" \
-                or m == "cached_property" \
-                # do not report __class__.__setter__ as a property
-                # eirannejad 2024-02-07:
-                # not sure if there are other cases but this passes the tests
-                or (m.endswith(".setter") and not m.startswith('__class__'))
+    lambda m: m == "property"
+            or m == "cached_property"
+            # do not report __class__.__setter__ as a property
+            # eirannejad 2024-02-07:
+            # not sure if there are other cases but this passes the tests
+            or (m.endswith(".setter") and not m.startswith('__class__'))
 )

--- a/jedi/parser_utils.py
+++ b/jedi/parser_utils.py
@@ -320,7 +320,7 @@ def expr_is_dotted(node):
     return node.type == 'name'
 
 
-def _function_is_x_method(*method_names):
+def _function_is_x_method(decorator_checker):
     def wrapper(function_node):
         """
         This is a heuristic. It will not hold ALL the times, but it will be
@@ -330,12 +330,12 @@ def _function_is_x_method(*method_names):
         """
         for decorator in function_node.get_decorators():
             dotted_name = decorator.children[1]
-            if dotted_name.get_code() in method_names:
+            if decorator_checker(dotted_name.get_code()):
                 return True
         return False
     return wrapper
 
 
-function_is_staticmethod = _function_is_x_method('staticmethod')
-function_is_classmethod = _function_is_x_method('classmethod')
-function_is_property = _function_is_x_method('property', 'cached_property')
+function_is_staticmethod = _function_is_x_method(lambda m: m == 'staticmethod')
+function_is_classmethod = _function_is_x_method(lambda m: m == 'classmethod')
+function_is_property = _function_is_x_method(lambda m: m == 'property' or m == 'cached_property' or m.endswith('.setter'))

--- a/jedi/parser_utils.py
+++ b/jedi/parser_utils.py
@@ -336,6 +336,8 @@ def _function_is_x_method(decorator_checker):
     return wrapper
 
 
-function_is_staticmethod = _function_is_x_method(lambda m: m == 'staticmethod')
-function_is_classmethod = _function_is_x_method(lambda m: m == 'classmethod')
-function_is_property = _function_is_x_method(lambda m: m == 'property' or m == 'cached_property' or m.endswith('.setter'))
+function_is_staticmethod = _function_is_x_method(lambda m: m == "staticmethod")
+function_is_classmethod = _function_is_x_method(lambda m: m == "classmethod")
+function_is_property = _function_is_x_method(
+    lambda m: m == "property" or m == "cached_property" or m.endswith(".setter")
+)

--- a/jedi/parser_utils.py
+++ b/jedi/parser_utils.py
@@ -340,9 +340,9 @@ function_is_staticmethod = _function_is_x_method(lambda m: m == "staticmethod")
 function_is_classmethod = _function_is_x_method(lambda m: m == "classmethod")
 function_is_property = _function_is_x_method(
     lambda m: m == "property"
-            or m == "cached_property"
-            # do not report __class__.__setter__ as a property
-            # eirannejad 2024-02-07:
-            # not sure if there are other cases but this passes the tests
-            or (m.endswith(".setter") and not m.startswith('__class__'))
+    or m == "cached_property"
+    # do not report __class__.__setter__ as a property
+    # eirannejad 2024-02-07:
+    # not sure if there are other cases but this passes the tests
+    or (m.endswith(".setter") and not m.startswith('__class__'))
 )

--- a/jedi/parser_utils.py
+++ b/jedi/parser_utils.py
@@ -339,5 +339,10 @@ def _function_is_x_method(decorator_checker):
 function_is_staticmethod = _function_is_x_method(lambda m: m == "staticmethod")
 function_is_classmethod = _function_is_x_method(lambda m: m == "classmethod")
 function_is_property = _function_is_x_method(
-    lambda m: m == "property" or m == "cached_property" or m.endswith(".setter")
+    lambda m: m == "property" \
+                or m == "cached_property" \
+                # do not report __class__.__setter__ as a property
+                # eirannejad 2024-02-07:
+                # not sure if there are other cases but this passes the tests
+                or (m.endswith(".setter") and not m.startswith('__class__'))
 )

--- a/jedi/parser_utils.py
+++ b/jedi/parser_utils.py
@@ -341,8 +341,5 @@ function_is_classmethod = _function_is_x_method(lambda m: m == "classmethod")
 function_is_property = _function_is_x_method(
     lambda m: m == "property"
     or m == "cached_property"
-    # do not report __class__.__setter__ as a property
-    # eirannejad 2024-02-07:
-    # not sure if there are other cases but this passes the tests
-    or (m.endswith(".setter") and not m.startswith('__class__'))
+    or (m.endswith(".setter"))
 )

--- a/test/completion/context.py
+++ b/test/completion/context.py
@@ -21,12 +21,10 @@ class Y(X):
     #? []
     def __doc__
 
-    # This might or might not be what we wanted, currently properties are also
-    # used like this. IMO this is not wanted ~dave.
-    #? ['__class__']
-    def __class__
     #? []
-    __class__
+    def __class__
+    #? ['__class__']
+    __class__ 
 
 
     #? ['__repr__']

--- a/test/completion/context.py
+++ b/test/completion/context.py
@@ -24,7 +24,7 @@ class Y(X):
     #? []
     def __class__
     #? ['__class__']
-    __class__ 
+    __class__
 
 
     #? ['__repr__']

--- a/test/test_api/test_classes.py
+++ b/test/test_api/test_classes.py
@@ -348,8 +348,8 @@ def test_parent_on_comprehension(Script):
 
 def test_type(Script):
     for c in Script('a = [str()]; a[0].').complete():
-        if c.name == '__class__' and False:  # TODO fix.
-            assert c.type == 'class'
+        if c.name == '__class__':
+            assert c.type == 'property'
         else:
             assert c.type in ('function', 'statement')
 

--- a/test/test_api/test_classes.py
+++ b/test/test_api/test_classes.py
@@ -348,8 +348,8 @@ def test_parent_on_comprehension(Script):
 
 def test_type(Script):
     for c in Script('a = [str()]; a[0].').complete():
-        if c.name == '__class__':
-            assert c.type == 'property'
+        if c.name == '__class__' and False:  # TODO fix.
+            assert c.type == 'class'
         else:
             assert c.type in ('function', 'statement')
 


### PR DESCRIPTION
When complete is called on this script, current jedi reports `X` as a `'method'` instead of a `'property'`. This PR fixes that


```python
class Point3d:
    @property
    def X(self) -> float:
        return 0.0

    @X.setter
    def X(self, value: float):
        return None

p = Point3d()
p.
```