### PR TITLE
Support Python 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, windows-2019]
-        python-version: ["3.12", "3.11", "3.10", "3.9", "3.8", "3.7", "3.6"]
-        environment: ['3.8', '3.12', '3.11', '3.10', '3.9', '3.7', '3.6', 'interpreter']
+        python-version: ["3.13", "3.12", "3.11", "3.10", "3.9", "3.8", "3.7", "3.6"]
+        environment: ['3.8', '3.13', '3.12', '3.11', '3.10', '3.9', '3.7', '3.6', 'interpreter']
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,8 @@ Changelog
 Unreleased
 ++++++++++
 
+- Python 3.13 support
+
 0.19.1 (2023-10-02)
 +++++++++++++++++++
 

--- a/jedi/api/environment.py
+++ b/jedi/api/environment.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 
 _VersionInfo = namedtuple('VersionInfo', 'major minor micro')  # type: ignore[name-match]
 
-_SUPPORTED_PYTHONS = ['3.12', '3.11', '3.10', '3.9', '3.8', '3.7', '3.6']
+_SUPPORTED_PYTHONS = ['3.13', '3.12', '3.11', '3.10', '3.9', '3.8', '3.7', '3.6']
 _SAFE_PATHS = ['/usr/bin', '/usr/local/bin']
 _CONDA_VAR = 'CONDA_PREFIX'
 _CURRENT_VERSION = '%s.%s' % (sys.version_info.major, sys.version_info.minor)

--- a/jedi/inference/__init__.py
+++ b/jedi/inference/__init__.py
@@ -90,7 +90,7 @@ class InferenceState:
         self.compiled_subprocess = environment.get_inference_state_subprocess(self)
         self.grammar = environment.get_grammar()
 
-        self.latest_grammar = parso.load_grammar(version='3.12')
+        self.latest_grammar = parso.load_grammar(version='3.13')
         self.memoize_cache = {}  # for memoize decorators
         self.module_cache = imports.ModuleCache()  # does the job of `sys.modules`.
         self.stub_module_cache = {}  # Dict[Tuple[str, ...], Optional[ModuleValue]]

--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,8 @@ setup(name='jedi',
       long_description=readme,
       packages=find_packages(exclude=['test', 'test.*']),
       python_requires='>=3.6',
-      # Python 3.11 & 3.12 grammars are added to parso in 0.8.3
-      install_requires=['parso>=0.8.3,<0.9.0'],
+      # Python 3.13 grammars are added to parso in 0.8.4
+      install_requires=['parso>=0.8.4,<0.9.0'],
       extras_require={
           'testing': [
               'pytest<9.0.0',
@@ -101,6 +101,7 @@ setup(name='jedi',
           'Programming Language :: Python :: 3.10',
           'Programming Language :: Python :: 3.11',
           'Programming Language :: Python :: 3.12',
+          'Programming Language :: Python :: 3.13',
           'Topic :: Software Development :: Libraries :: Python Modules',
           'Topic :: Text Editors :: Integrated Development Environments (IDE)',
           'Topic :: Utilities',

--- a/test/test_api/test_interpreter.py
+++ b/test/test_api/test_interpreter.py
@@ -310,8 +310,9 @@ def test_completion_param_annotations():
     # Need to define this function not directly in Python. Otherwise Jedi is too
     # clever and uses the Python code instead of the signature object.
     code = 'def foo(a: 1, b: str, c: int = 1.0) -> bytes: pass'
-    exec(code, locals())
-    script = jedi.Interpreter('foo', [locals()])
+    exec_locals = {}
+    exec(code, exec_locals)
+    script = jedi.Interpreter('foo', [exec_locals])
     c, = script.complete()
     sig, = c.get_signatures()
     a, b, c = sig.params
@@ -323,7 +324,7 @@ def test_completion_param_annotations():
     assert b.description == 'param b: str'
     assert c.description == 'param c: int=1.0'
 
-    d, = jedi.Interpreter('foo()', [locals()]).infer()
+    d, = jedi.Interpreter('foo()', [exec_locals]).infer()
     assert d.name == 'bytes'
 
 

--- a/test/test_api/test_interpreter.py
+++ b/test/test_api/test_interpreter.py
@@ -526,9 +526,13 @@ def test_partial_signatures(code, expected, index):
     c = functools.partial(func, 1, c=2)
 
     sig, = jedi.Interpreter(code, [locals()]).get_signatures()
-    assert sig.name == 'partial'
     assert [p.name for p in sig.params] == expected
     assert index == sig.index
+
+    if sys.version_info < (3, 13):
+        # Python 3.13.0b3 makes functools.partial be a descriptor, which breaks
+        # Jedi's `py__name__` detection; see https://github.com/davidhalter/jedi/issues/2012
+        assert sig.name == 'partial'
 
 
 def test_type_var():

--- a/test/test_inference/test_signature.py
+++ b/test/test_inference/test_signature.py
@@ -1,5 +1,5 @@
 from textwrap import dedent
-from operator import ge, lt
+from operator import eq, ge, lt
 import re
 import os
 
@@ -14,7 +14,8 @@ from ..helpers import get_example_dir
         ('import math; math.cos', 'cos(x, /)', ['x'], ge, (3, 6)),
 
         ('next', 'next(iterator, default=None, /)', ['iterator', 'default'], lt, (3, 12)),
-        ('next', 'next()', [], ge, (3, 12)),
+        ('next', 'next()', [], eq, (3, 12)),
+        ('next', 'next(iterator, default=None, /)', ['iterator', 'default'], ge, (3, 13)),
 
         ('str', "str(object='', /) -> str", ['object'], ge, (3, 6)),
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -78,9 +78,9 @@ class TestSetupReadline(unittest.TestCase):
         # items as well as items that are not only available on linux.
         difference = set(self.complete(s)).symmetric_difference(goal)
         ACCEPTED_DIFFERENCE_PREFIXES = [
-            '_', 'O_', 'EX_', 'MFD_',
+            '_', 'O_', 'EX_', 'EFD_', 'MFD_', 'TFD_',
             'SF_', 'ST_', 'CLD_', 'POSIX_SPAWN_', 'P_',
-            'RWF_', 'CLONE_', 'SCHED_',
+            'RWF_', 'CLONE_', 'SCHED_', 'SPLICE_',
         ]
         difference = {
             x for x in difference

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -84,8 +84,10 @@ class TestSetupReadline(unittest.TestCase):
         ]
         difference = {
             x for x in difference
-            if all(not x.startswith('from os import ' + prefix)
-                   for prefix in ACCEPTED_DIFFERENCE_PREFIXES)
+            if not any(
+                x.startswith('from os import ' + prefix)
+                for prefix in ACCEPTED_DIFFERENCE_PREFIXES
+            )
         }
         # There are quite a few differences, because both Windows and Linux
         # (posix and nt) libraries are included.

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -73,15 +73,19 @@ class TestSetupReadline(unittest.TestCase):
         import os
         s = 'from os import '
         goal = {s + el for el in dir(os)}
+
         # There are minor differences, e.g. the dir doesn't include deleted
         # items as well as items that are not only available on linux.
         difference = set(self.complete(s)).symmetric_difference(goal)
+        ACCEPTED_DIFFERENCE_PREFIXES = [
+            '_', 'O_', 'EX_', 'MFD_',
+            'SF_', 'ST_', 'CLD_', 'POSIX_SPAWN_', 'P_',
+            'RWF_', 'CLONE_', 'SCHED_',
+        ]
         difference = {
             x for x in difference
-            if all(not x.startswith('from os import ' + s)
-                   for s in ['_', 'O_', 'EX_', 'MFD_', 'SF_', 'ST_',
-                             'CLD_', 'POSIX_SPAWN_', 'P_', 'RWF_',
-                             'CLONE_', 'SCHED_'])
+            if all(not x.startswith('from os import ' + prefix)
+                   for prefix in ACCEPTED_DIFFERENCE_PREFIXES)
         }
         # There are quite a few differences, because both Windows and Linux
         # (posix and nt) libraries are included.


### PR DESCRIPTION
Various fixes to get the tests passing on Python 3.13, all within the tests themselves.
Also some small tidyups in one of the tests.
Moves to the 3.13 grammar from parso 0.8.4 and add testing on 3.13.

Reviewing by commit may be useful.

Fixes https://github.com/davidhalter/jedi/issues/2002.

Discovered issues:
- `pathlib` has been refactored, there's now `pathlib._local` and `pathlib._abc`, which breaks passing pickled objects to subprocesses with different Python versions
- `functools.partial` is now a descriptor, which breaks `DirectObjectAccess.py__name__`'s assumptions (broken out into #2012)
