### PR TITLE
Enable linting of our test code, but not our test data files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Run tests
         run: |
-          python -m flake8 jedi setup.py
+          python -m flake8 jedi test setup.py
           python -m mypy jedi sith.py setup.py
 
   coverage:

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,13 @@ per-file-ignores =
   jedi/__init__.py:F401
   jedi/inference/compiled/__init__.py:F401
   jedi/inference/value/__init__.py:F401
-exclude = jedi/third_party/* .tox/*
+exclude =
+  .tox/*
+  jedi/third_party/*
+  test/completion/*
+  test/examples/*
+  test/refactor/*
+  test/static_analysis/*
 
 [pycodestyle]
 max-line-length = 100

--- a/test/test_api/test_context.py
+++ b/test/test_api/test_context.py
@@ -17,7 +17,7 @@ def func1(x, y):
 def func2():
  what ?
 i = 3
-    
+
 def func3():
     1'''
 cls_code = '''\

--- a/test/test_api/test_interpreter.py
+++ b/test/test_api/test_interpreter.py
@@ -26,7 +26,7 @@ def get_completion(source, namespace):
 
 
 def test_builtin_details():
-    import keyword
+    import keyword  # noqa: F401
 
     class EmptyClass:
         pass
@@ -53,9 +53,9 @@ def test_numpy_like_non_zero():
     """
 
     class NumpyNonZero:
-
         def __zero__(self):
             raise ValueError('Numpy arrays would raise and tell you to use .any() or all()')
+
         def __bool__(self):
             raise ValueError('Numpy arrays would raise and tell you to use .any() or all()')
 
@@ -113,17 +113,17 @@ def _assert_interpreter_complete(source, namespace, completions, *, check_type=F
 
 
 def test_complete_raw_function():
-    from os.path import join
+    from os.path import join  # noqa: F401
     _assert_interpreter_complete('join("").up', locals(), ['upper'])
 
 
 def test_complete_raw_function_different_name():
-    from os.path import join as pjoin
+    from os.path import join as pjoin  # noqa: F401
     _assert_interpreter_complete('pjoin("").up', locals(), ['upper'])
 
 
 def test_complete_raw_module():
-    import os
+    import os  # noqa: F401
     _assert_interpreter_complete('os.path.join("a").up', locals(), ['upper'])
 
 
@@ -281,7 +281,7 @@ def test_param_completion():
     def foo(bar):
         pass
 
-    lambd = lambda xyz: 3
+    lambd = lambda xyz: 3  # noqa: E731
 
     _assert_interpreter_complete('foo(bar', locals(), ['bar='])
     _assert_interpreter_complete('lambd(xyz', locals(), ['xyz='])
@@ -295,7 +295,7 @@ def test_endless_yield():
 
 
 def test_completion_params():
-    foo = lambda a, b=3: None
+    foo = lambda a, b=3: None  # noqa: E731
 
     script = jedi.Interpreter('foo', [locals()])
     c, = script.complete()
@@ -409,7 +409,7 @@ def test_dir_magic_method(allow_unsafe_getattr):
 def test_name_not_findable():
     class X():
         if 0:
-            NOT_FINDABLE
+            NOT_FINDABLE  # noqa: F821
 
         def hidden(self):
             return
@@ -422,7 +422,7 @@ def test_name_not_findable():
 
 
 def test_stubs_working():
-    from multiprocessing import cpu_count
+    from multiprocessing import cpu_count  # noqa: F401
     defs = jedi.Interpreter("cpu_count()", [locals()]).infer()
     assert [d.name for d in defs] == ['int']
 
@@ -532,7 +532,6 @@ def test_partial_signatures(code, expected, index):
 
 def test_type_var():
     """This was an issue before, see Github #1369"""
-    import typing
     x = typing.TypeVar('myvar')
     def_, = jedi.Interpreter('x', [locals()]).infer()
     assert def_.name == 'TypeVar'
@@ -610,7 +609,7 @@ def test_dict_getitem(code, types):
         ('next(DunderCls())', 'float'),
         ('next(dunder)', 'float'),
         ('for x in DunderCls(): x', 'str'),
-        #('for x in dunder: x', 'str'),
+        # ('for x in dunder: x', 'str'),
     ]
 )
 def test_dunders(class_is_findable, code, expected, allow_unsafe_getattr):
@@ -687,7 +686,7 @@ def bar():
     ]
 )
 def test_string_annotation(annotations, result, code):
-    x = lambda foo: 1
+    x = lambda foo: 1  # noqa: E731
     x.__annotations__ = annotations
     defs = jedi.Interpreter(code or 'x()', [locals()]).infer()
     assert [d.name for d in defs] == result
@@ -720,8 +719,8 @@ def test_negate():
 
 def test_complete_not_findable_class_source():
     class TestClass():
-        ta=1
-        ta1=2
+        ta = 1
+        ta1 = 2
 
     # Simulate the environment where the class is defined in
     # an interactive session and therefore inspect module
@@ -756,7 +755,7 @@ def test_param_infer_default():
     ],
 )
 def test_keyword_param_completion(code, expected):
-    import random
+    import random  # noqa: F401
     completions = jedi.Interpreter(code, [locals()]).complete()
     assert expected == [c.name for c in completions if c.name.endswith('=')]
 

--- a/test/test_api/test_project.py
+++ b/test/test_api/test_project.py
@@ -144,13 +144,17 @@ def test_load_save_project(tmpdir):
     ]
 )
 def test_search(string, full_names, kwargs):
-    some_search_test_var = 1.0
+    some_search_test_var = 1.0  # noqa: F841
     project = Project(test_dir)
     if kwargs.pop('complete', False) is True:
         defs = project.complete_search(string, **kwargs)
     else:
         defs = project.search(string, **kwargs)
-    assert sorted([('stub:' if d.is_stub() else '') + (d.full_name or d.name) for d in defs]) == full_names
+    actual = sorted([
+        ('stub:' if d.is_stub() else '') + (d.full_name or d.name)
+        for d in defs
+    ])
+    assert actual == full_names
 
 
 @pytest.mark.parametrize(
@@ -169,8 +173,8 @@ def test_complete_search(Script, string, completions, all_scopes):
 
 @pytest.mark.parametrize(
     'path,expected', [
-        (Path(__file__).parents[2], True), # The path of the project
-        (Path(__file__).parents[1], False), # The path of the tests, not a project
+        (Path(__file__).parents[2], True),  # The path of the project
+        (Path(__file__).parents[1], False),  # The path of the tests, not a project
         (Path.home(), None)
     ]
 )

--- a/test/test_api/test_refactoring.py
+++ b/test/test_api/test_refactoring.py
@@ -113,7 +113,7 @@ def test_diff_without_ending_newline(Script):
          b
         -a
         +c
-        ''')
+        ''')  # noqa: W291
 
 
 def test_diff_path_outside_of_project(Script):

--- a/test/test_api/test_search.py
+++ b/test/test_api/test_search.py
@@ -1,5 +1,5 @@
 import os
-import sys
+import sys  # noqa: F401
 
 import pytest
 

--- a/test/test_debug.py
+++ b/test/test_debug.py
@@ -1,6 +1,7 @@
 import jedi
 from jedi import debug
 
+
 def test_simple():
     jedi.set_debug_function()
     debug.speed('foo')

--- a/test/test_inference/test_docstring.py
+++ b/test/test_inference/test_docstring.py
@@ -206,6 +206,7 @@ def test_numpydoc_parameters_set_of_values():
     assert 'capitalize' in names
     assert 'numerator' in names
 
+
 @pytest.mark.skipif(numpydoc_unavailable,
                     reason='numpydoc module is unavailable')
 def test_numpydoc_parameters_set_single_value():
@@ -390,7 +391,8 @@ def test_numpydoc_yields():
 @pytest.mark.skipif(numpydoc_unavailable or numpy_unavailable,
                     reason='numpydoc or numpy module is unavailable')
 def test_numpy_returns():
-    s = dedent('''
+    s = dedent(
+        '''
         import numpy
         x = numpy.asarray([])
         x.d'''
@@ -402,7 +404,8 @@ def test_numpy_returns():
 @pytest.mark.skipif(numpydoc_unavailable or numpy_unavailable,
                     reason='numpydoc or numpy module is unavailable')
 def test_numpy_comp_returns():
-    s = dedent('''
+    s = dedent(
+        '''
         import numpy
         x = numpy.array([])
         x.d'''

--- a/test/test_inference/test_extension.py
+++ b/test/test_inference/test_extension.py
@@ -33,7 +33,9 @@ def test_get_signatures_stdlib(Script):
 
 # Check only on linux 64 bit platform and Python3.8.
 @pytest.mark.parametrize('load_unsafe_extensions', [False, True])
-@pytest.mark.skipif('sys.platform != "linux" or sys.maxsize <= 2**32 or sys.version_info[:2] != (3, 8)')
+@pytest.mark.skipif(
+    'sys.platform != "linux" or sys.maxsize <= 2**32 or sys.version_info[:2] != (3, 8)',
+)
 def test_init_extension_module(Script, load_unsafe_extensions):
     """
     ``__init__`` extension modules are also packages and Jedi should understand

--- a/test/test_inference/test_gradual/test_typeshed.py
+++ b/test/test_inference/test_gradual/test_typeshed.py
@@ -222,7 +222,7 @@ def test_goto_stubs_on_itself(Script, code, type_):
 
 def test_module_exists_only_as_stub(Script):
     try:
-        import redis
+        import redis  # noqa: F401
     except ImportError:
         pass
     else:
@@ -234,7 +234,7 @@ def test_module_exists_only_as_stub(Script):
 
 def test_django_exists_only_as_stub(Script):
     try:
-        import django
+        import django  # noqa: F401
     except ImportError:
         pass
     else:

--- a/test/test_inference/test_literals.py
+++ b/test/test_inference/test_literals.py
@@ -1,4 +1,3 @@
-import pytest
 from jedi.inference.value import TreeInstance
 
 

--- a/test/test_inference/test_sys_path.py
+++ b/test/test_inference/test_sys_path.py
@@ -48,8 +48,8 @@ def test_venv_and_pths(venv_path, environment):
 
     ETALON = [
         # For now disable egg-links. I have no idea how they work... ~ dave
-        #pjoin('/path', 'from', 'egg-link'),
-        #pjoin(site_pkg_path, '.', 'relative', 'egg-link', 'path'),
+        # pjoin('/path', 'from', 'egg-link'),
+        # pjoin(site_pkg_path, '.', 'relative', 'egg-link', 'path'),
         site_pkg_path,
         pjoin(site_pkg_path, 'dir-from-foo-pth'),
         '/foo/smth.py:module',

--- a/test/test_parso_integration/test_basic.py
+++ b/test/test_parso_integration/test_basic.py
@@ -1,6 +1,5 @@
 from textwrap import dedent
 
-import pytest
 from parso import parse
 
 


### PR DESCRIPTION
This aims to make development of tests easier by adding more automated checks for minor errors. It also makes some slightly unusual code more explicit about what it's doing by requiring markers.