### PR TITLE
Fix race condition around subprocess inference state tidyup

### DIFF
--- a/jedi/api/environment.py
+++ b/jedi/api/environment.py
@@ -8,12 +8,17 @@ import hashlib
 import filecmp
 from collections import namedtuple
 from shutil import which
+from typing import TYPE_CHECKING
 
 from jedi.cache import memoize_method, time_cache
 from jedi.inference.compiled.subprocess import CompiledSubprocess, \
     InferenceStateSameProcess, InferenceStateSubprocess
 
 import parso
+
+if TYPE_CHECKING:
+    from jedi.inference import InferenceState
+
 
 _VersionInfo = namedtuple('VersionInfo', 'major minor micro')  # type: ignore[name-match]
 
@@ -102,7 +107,10 @@ class Environment(_BaseEnvironment):
         version = '.'.join(str(i) for i in self.version_info)
         return '<%s: %s in %s>' % (self.__class__.__name__, version, self.path)
 
-    def get_inference_state_subprocess(self, inference_state):
+    def get_inference_state_subprocess(
+        self,
+        inference_state: 'InferenceState',
+    ) -> InferenceStateSubprocess:
         return InferenceStateSubprocess(inference_state, self._get_subprocess())
 
     @memoize_method
@@ -134,7 +142,10 @@ class SameEnvironment(_SameEnvironmentMixin, Environment):
 
 
 class InterpreterEnvironment(_SameEnvironmentMixin, _BaseEnvironment):
-    def get_inference_state_subprocess(self, inference_state):
+    def get_inference_state_subprocess(
+        self,
+        inference_state: 'InferenceState',
+    ) -> InferenceStateSameProcess:
         return InferenceStateSameProcess(inference_state)
 
     def get_sys_path(self):

--- a/jedi/inference/compiled/subprocess/__init__.py
+++ b/jedi/inference/compiled/subprocess/__init__.py
@@ -284,9 +284,6 @@ class CompiledSubprocess:
 class Listener:
     def __init__(self):
         self._inference_states = {}
-        # TODO refactor so we don't need to process anymore just handle
-        # controlling.
-        self._process = _InferenceStateProcess(Listener)
 
     def _get_inference_state(self, function, inference_state_id):
         from jedi.inference import InferenceState

--- a/jedi/inference/compiled/subprocess/__init__.py
+++ b/jedi/inference/compiled/subprocess/__init__.py
@@ -128,7 +128,7 @@ class InferenceStateSubprocess(_InferenceStateProcess):
             self._used = True
 
             result = self._compiled_subprocess.run(
-                self._inference_state_weakref(),
+                self._inference_state_id,
                 func,
                 args=args,
                 kwargs=kwargs,
@@ -213,18 +213,18 @@ class CompiledSubprocess:
                                                   t)
         return process
 
-    def run(self, inference_state, function, args=(), kwargs={}):
+    def run(self, inference_state_id, function, args=(), kwargs={}):
         # Delete old inference_states.
         while True:
             try:
-                inference_state_id = self._inference_state_deletion_queue.pop()
+                delete_id = self._inference_state_deletion_queue.pop()
             except IndexError:
                 break
             else:
-                self._send(inference_state_id, None)
+                self._send(delete_id, None)
 
         assert callable(function)
-        return self._send(id(inference_state), function, args, kwargs)
+        return self._send(inference_state_id, function, args, kwargs)
 
     def get_sys_path(self):
         return self._send(None, functions.get_sys_path, (), {})


### PR DESCRIPTION
## Summary

There was a race condition due to the combination of Python's object ids being re-usable and Jedi persisting such ids beyond the real lifeteime of some objects. This could lead to the subprocess' view of the lifetime of `InferenceState` contexts getting out of step with that in the parent process and resulting in errors when removing them. It is also possible that this could result in erroneous results being reported, however this was not directly observed.

The race was specifically:
- `InferenceState` A created, gets id 1
- `InferenceStateSubprocess` A' created, uses `InferenceState` A which it stores as a weakref and an id
- `InferenceStateSubprocess` A' is used, the sub-process learns about an `InferenceState` with id 1
- `InferenceState` A goes away, `InferenceStateSubprocess` A' is not yet garbage collected
- `InferenceState` B created, gets id 1
- `InferenceStateSubprocess` B' created, uses `InferenceState` B which it stores as a weakref and an id
- `InferenceStateSubprocess` B' is used, the sub-process re-uses its entry for an `InferenceState` with id 1

At this point the order of operations between the two `InferenceStateSubprocess` instances going away is immaterial -- both will trigger a removal of a state with id 1. As long as B' doesn't try to use the sub-process again after the first removal has happened then the second removal will fail.

This change resolves the race condition by coupling the context in the subprocess to the corresponding manager class instance in the parent process, rather than to the consumer `InferenceState`.

See inline comments for further details.

## Code review

Suggest review by commit. There's some small refactors in the early commits. The actual fix is the last commit on the branch.

### Testing

I'm open to ideas on how to add a test for this.

Currently this is relying on Python 3.13 tests reproducing the issue fairly easily, though not entirely consistently.

### Links

Currently builds on https://github.com/davidhalter/jedi/pull/2003 (as it was discovered there), though it doesn't really need to be part of the upgrade process.