### PR TITLE
When inferring comparison operators, return a definite type instead of NO_VALUES for the in/not in operator

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -64,6 +64,7 @@ Code Contributors
 - Joseph Birkner (@josephbirkner)
 - Márcio Mazza (@marciomazza)
 - Martin Vielsmaier (@moser) <martin@vielsmaier.net>
+- TingJia Wu (@WutingjiaX) <wutingjia@bytedance.com>
 
 And a few more "anonymous" contributors.
 

--- a/jedi/inference/syntax_tree.py
+++ b/jedi/inference/syntax_tree.py
@@ -645,7 +645,10 @@ def _infer_comparison_part(inference_state, context, left, operator, right):
             _bool_to_value(inference_state, False)
         ])
     elif str_operator in ('in', 'not in'):
-        return NO_VALUES
+        return ValueSet([
+            _bool_to_value(inference_state, True),
+            _bool_to_value(inference_state, False)
+        ])
 
     def check(obj):
         """Checks if a Jedi object is either a float or an int."""

--- a/test/test_api/test_api.py
+++ b/test/test_api/test_api.py
@@ -403,3 +403,8 @@ def test_infer_after_parentheses(Script, code, column, expected):
         assert completions == []
     else:
         assert [c.name for c in completions] == [expected]
+
+
+def test_infer_in_operator(Script):
+    completions = Script("res = 'f' in 'foo'").infer(column=1)
+    assert completions[0].full_name == 'builtins.bool'


### PR DESCRIPTION
As discussed in #2010