### PR TITLE
 When inferring comparison operators, return a definite type instead of NO_VALUES for the in/not in operator

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -64,6 +64,7 @@ Code Contributors
 - Joseph Birkner (@josephbirkner)
 - Márcio Mazza (@marciomazza)
 - Martin Vielsmaier (@moser) <martin@vielsmaier.net>
+- TingJia Wu (@WutingjiaX) <wutingjia@bytedance.com>
 
 And a few more "anonymous" contributors.
 

--- a/jedi/inference/syntax_tree.py
+++ b/jedi/inference/syntax_tree.py
@@ -645,7 +645,10 @@ def _infer_comparison_part(inference_state, context, left, operator, right):
             _bool_to_value(inference_state, False)
         ])
     elif str_operator in ('in', 'not in'):
-        return NO_VALUES
+        return ValueSet([
+            _bool_to_value(inference_state, True),
+            _bool_to_value(inference_state, False)
+        ])
 
     def check(obj):
         """Checks if a Jedi object is either a float or an int."""

--- a/test/completion/basic.py
+++ b/test/completion/basic.py
@@ -424,3 +424,10 @@ with open("a"), open("b") as bfile:
 some_array = ['', '']
 #! ['def upper']
 some_array[some_not_defined_index].upper
+
+# -----------------
+# operator
+# -----------------
+
+#? bool()
+res = 'f' in 'foo'; res


### PR DESCRIPTION
As discussed in #2010 