### PR TITLE
Support dataclass transform

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -157,6 +157,14 @@ def jedi_path():
 
 
 @pytest.fixture()
+def skip_pre_python311(environment):
+    if environment.version_info < (3, 11):
+        # This if is just needed to avoid that tests ever skip way more than
+        # they should for all Python versions.
+        pytest.skip()
+
+
+@pytest.fixture()
 def skip_pre_python38(environment):
     if environment.version_info < (3, 8):
         # This if is just needed to avoid that tests ever skip way more than

--- a/jedi/inference/value/klass.py
+++ b/jedi/inference/value/klass.py
@@ -275,6 +275,9 @@ class ClassMixin:
         is_dataclass_transform = False
         for cls in reversed(list(self.py__mro__())):
             if not is_dataclass_transform and (
+                # If dataclass_transform is applied to a class, dataclass-like semantics
+                # will be assumed for any class that directly or indirectly derives from
+                # the decorated class or uses the decorated class as a metaclass.
                 isinstance(cls, DataclassWrapper)
                 or (
                     # Some object like CompiledValues would not be compatible

--- a/jedi/inference/value/klass.py
+++ b/jedi/inference/value/klass.py
@@ -295,7 +295,7 @@ class ClassMixin:
                 # Internal leakage :|
                 and isinstance(meta._wrapped_value, DataclassTransformer)
             ):
-                return True, meta._wrapped_value.init_mode_from_new
+                return True, meta._wrapped_value.init_mode_from_new()
 
         return False, None
 
@@ -342,8 +342,8 @@ class ClassMixin:
                 is_dataclass_transform
                 and isinstance(cls, ClassValue)
                 and (
-                    cls.init_param_mode
-                    or (cls.init_param_mode is None and default_init_mode)
+                    cls.init_param_mode()
+                    or (cls.init_param_mode() is None and default_init_mode)
                 )
             ):
                 param_names.extend(
@@ -545,7 +545,6 @@ class DataclassTransformer(ValueWrapper, ClassMixin):
     def __init__(self, wrapped_value):
         super().__init__(wrapped_value)
 
-    @property
     def init_mode_from_new(self) -> bool:
         """Default value if missing is ``True``"""
         new_methods = self._wrapped_value.py__getattribute__("__new__")
@@ -676,7 +675,6 @@ class ClassValue(ClassMixin, FunctionAndClassBase, metaclass=CachedMetaClass):
                         return values
         return NO_VALUES
 
-    @property
     def init_param_mode(self) -> Optional[bool]:
         """
         It returns ``True`` if ``class X(init=False):`` else ``False``.

--- a/jedi/inference/value/klass.py
+++ b/jedi/inference/value/klass.py
@@ -174,9 +174,6 @@ def get_dataclass_param_names(cls) -> List[DataclassParamName]:
     """
     param_names = []
     filter_ = cls.as_context().get_global_filter()
-    # .values ordering is not guaranteed, at least not in
-    # Python < 3.6, when dicts where not ordered, which is an
-    # implementation detail anyway.
     for name in sorted(filter_.values(), key=lambda name: name.start_pos):
         d = name.tree_name.get_definition()
         annassign = d.children[1]
@@ -464,13 +461,6 @@ class ClassMixin:
 class DataclassParamName(BaseTreeParamName):
     """
     Represent a field declaration on a class with dataclass semantics.
-
-    .. code:: python
-
-        class A:
-            a: int
-
-    ``a`` is a :class:`DataclassParamName`.
     """
 
     def __init__(self, parent_context, tree_name, annotation_node, default_node):
@@ -547,7 +537,7 @@ class DataclassDecorator(ValueWrapper, FunctionMixin):
 
 class DataclassTransformer(ValueWrapper, ClassMixin):
     """
-    A class with ``dataclass_transform`` applies. dataclass-like semantics will
+    A class decorated with ``dataclass_transform``. dataclass-like semantics will
     be assumed for any class that directly or indirectly derives from the
     decorated class or uses the decorated class as a metaclass. Attributes on
     the decorated class and its base classes are not considered to be fields.
@@ -593,11 +583,14 @@ class DataclassWrapper(ValueWrapper, ClassMixin):
 
     .. code:: python
 
-        @dataclass class A: ... # this
+        @dataclass
+        class A: ... # this
 
-        @dataclass_transform def create_model(): pass
+        @dataclass_transform
+        def create_model(): pass
 
-        @create_model() class B: ... # or this
+        @create_model()
+        class B: ... # or this
     """
 
     def __init__(

--- a/jedi/inference/value/klass.py
+++ b/jedi/inference/value/klass.py
@@ -49,7 +49,7 @@ from jedi.inference.arguments import unpack_arglist, ValuesArguments
 from jedi.inference.base_value import ValueSet, iterator_to_value_set, \
     NO_VALUES, ValueWrapper
 from jedi.inference.context import ClassContext
-from jedi.inference.value.function import FunctionAndClassBase, OverloadedFunctionValue
+from jedi.inference.value.function import FunctionAndClassBase, FunctionMixin
 from jedi.inference.value.decorator import Decoratee
 from jedi.inference.gradual.generics import LazyGenericManager, TupleGenericManager
 from jedi.plugins import plugin_manager
@@ -433,13 +433,13 @@ class DataclassSignature(AbstractSignature):
         return self._param_names
 
 
-class DataclassDecorator(OverloadedFunctionValue):
-    def __init__(self, function, overloaded_functions, arguments):
+class DataclassDecorator(ValueWrapper, FunctionMixin):
+    def __init__(self, function, arguments):
         """
         Args:
             arguments: The parameters to the dataclass function decorator.
         """
-        super().__init__(function, overloaded_functions)
+        super().__init__(function)
         self.arguments = arguments
 
     @property

--- a/jedi/inference/value/klass.py
+++ b/jedi/inference/value/klass.py
@@ -537,10 +537,11 @@ class DataclassDecorator(ValueWrapper, FunctionMixin):
 
 class DataclassTransformer(ValueWrapper, ClassMixin):
     """
-    A class decorated with ``dataclass_transform``. dataclass-like semantics will
-    be assumed for any class that directly or indirectly derives from the
-    decorated class or uses the decorated class as a metaclass. Attributes on
-    the decorated class and its base classes are not considered to be fields.
+    A class decorated with the ``dataclass_transform`` decorator. dataclass-like
+    semantics will be assumed for any class that directly or indirectly derives
+    from the decorated class or uses the decorated class as a metaclass.
+    Attributes on the decorated class and its base classes are not considered to
+    be fields.
     """
     def __init__(self, wrapped_value):
         super().__init__(wrapped_value)

--- a/jedi/inference/value/klass.py
+++ b/jedi/inference/value/klass.py
@@ -36,6 +36,8 @@ py__doc__()                            Returns the docstring for a value.
 ====================================== ========================================
 
 """
+from __future__ import annotations
+
 from typing import List, Optional, Tuple
 
 from jedi import debug
@@ -156,7 +158,7 @@ def init_param_value(arg_nodes) -> Optional[bool]:
     return None
 
 
-def get_dataclass_param_names(cls) -> List["DataclassParamName"]:
+def get_dataclass_param_names(cls) -> List[DataclassParamName]:
     """
     ``cls`` is a :class:`ClassMixin`. The type is only documented as mypy would
     complain that some fields are missing.
@@ -300,7 +302,7 @@ class ClassMixin:
 
         return False, None
 
-    def _get_dataclass_transform_signatures(self) -> List["DataclassSignature"]:
+    def _get_dataclass_transform_signatures(self) -> List[DataclassSignature]:
         """
         Returns: A non-empty list if the class has dataclass semantics else an
         empty list.

--- a/jedi/inference/value/klass.py
+++ b/jedi/inference/value/klass.py
@@ -146,6 +146,10 @@ def get_dataclass_param_names(cls):
         d = name.tree_name.get_definition()
         annassign = d.children[1]
         if d.type == 'expr_stmt' and annassign.type == 'annassign':
+            node = annassign.children[1]
+            if node.type == "atom_expr" and node.children[0].value == "ClassVar":
+                continue
+
             if len(annassign.children) < 4:
                 default = None
             else:

--- a/jedi/inference/value/klass.py
+++ b/jedi/inference/value/klass.py
@@ -252,7 +252,7 @@ class ClassMixin:
                     yield x
 
     def _has_dataclass_transform_metaclasses(self) -> bool:
-        for meta in self.get_metaclasses():
+        for meta in self.get_metaclasses():  # type: ignore[attr-defined]
             if (
                 # Not sure if necessary
                 isinstance(meta, DataclassWrapper)

--- a/jedi/plugins/stdlib.py
+++ b/jedi/plugins/stdlib.py
@@ -798,6 +798,12 @@ _implemented = {
         # runtime_checkable doesn't really change anything and is just
         # adding logs for infering stuff, so we can safely ignore it.
         'runtime_checkable': lambda value, arguments, callback: NO_VALUES,
+        # Python 3.11+
+        'dataclass_transform': _dataclass,
+    },
+    'typing_extensions': {
+        # Python <3.11
+        'dataclass_transform': _dataclass,
     },
     'dataclasses': {
         # For now this works at least better than Jedi trying to understand it.

--- a/jedi/plugins/stdlib.py
+++ b/jedi/plugins/stdlib.py
@@ -593,8 +593,9 @@ def _random_choice(sequences):
 def _dataclass(value, arguments, callback):
     """
     dataclass decorator can be called 2 times with different arguments. One to
-    customize it dataclass(eq=True) and another one with the class to
-    transform.
+    customize it dataclass(eq=True) and another one with the class to transform.
+
+    It supports dataclass, dataclass_transform and attrs.
     """
     for c in _follow_param(value.inference_state, arguments, 0):
         if c.is_class():

--- a/jedi/plugins/stdlib.py
+++ b/jedi/plugins/stdlib.py
@@ -615,8 +615,7 @@ def _dataclass(value, arguments, callback):
             return ValueSet(
                 [
                     DataclassDecorator(
-                        value._wrapped_value,
-                        value._overloaded_functions,
+                        value,
                         arguments=arguments,
                     )
                 ]

--- a/jedi/plugins/stdlib.py
+++ b/jedi/plugins/stdlib.py
@@ -625,9 +625,17 @@ def _dataclass(value, arguments, callback):
                 ]
             )
         elif c.is_function():
-            # dataclass_transform on a decorator equivalent of @dataclass
+            # @dataclass_transform
+            # def create_model(): pass
             return ValueSet([value])
-        elif value.name.string_name != "dataclass_transform":
+        elif (
+            # @dataclass(...)
+            value.name.string_name != "dataclass_transform"
+            # @dataclass_transform
+            # def create_model(): pass
+            # @create_model(...)
+            or isinstance(value, Decoratee)
+        ):
             # dataclass (or like) decorator customization
             return ValueSet(
                 [

--- a/jedi/plugins/stdlib.py
+++ b/jedi/plugins/stdlib.py
@@ -624,8 +624,11 @@ def _dataclass(value, arguments, callback):
                     )
                 ]
             )
-        else:
-            # Decorator customization
+        elif c.is_function():
+            # dataclass_transform on a decorator equivalent of @dataclass
+            return ValueSet([value])
+        elif value.name.string_name != "dataclass_transform":
+            # dataclass (or like) decorator customization
             return ValueSet(
                 [
                     DataclassDecorator(
@@ -634,6 +637,9 @@ def _dataclass(value, arguments, callback):
                     )
                 ]
             )
+        else:
+            # dataclass_transform decorator customization; nothing impactful
+            return ValueSet([value])
     return NO_VALUES
 
 
@@ -795,17 +801,6 @@ _implemented = {
     'dataclasses': {
         # For now this works at least better than Jedi trying to understand it.
         'dataclass': _dataclass
-    },
-    # attrs exposes declaration interface roughly compatible with dataclasses
-    # via attrs.define, attrs.frozen and attrs.mutable
-    # https://www.attrs.org/en/stable/names.html
-    'attr': {
-        'define': _dataclass,
-        'frozen': _dataclass,
-    },
-    'attrs': {
-        'define': _dataclass,
-        'frozen': _dataclass,
     },
     'os.path': {
         'dirname': _create_string_input_function(os.path.dirname),

--- a/jedi/plugins/stdlib.py
+++ b/jedi/plugins/stdlib.py
@@ -613,6 +613,9 @@ def _dataclass(value, arguments, callback):
                 # The decorator function from dataclass_transform acting as the
                 # dataclass decorator.
                 and not isinstance(value, Decoratee)
+                # The decorator function from dataclass_transform acting as the
+                # dataclass decorator with customized parameters
+                and not isinstance(value, DataclassDecorator)
             )
 
             return ValueSet(

--- a/jedi/plugins/stdlib.py
+++ b/jedi/plugins/stdlib.py
@@ -597,19 +597,26 @@ def _dataclass(value, arguments, callback):
     """
     for c in _follow_param(value.inference_state, arguments, 0):
         if c.is_class():
-            # Decorate the class
+            # Decorate a class
             dataclass_init = (
-                # Customized decorator
+                # Customized decorator, init may be disabled
                 not value.has_dataclass_init_false
                 if isinstance(value, DataclassDecorator)
-                # Bare dataclass decorator
+                # Bare dataclass decorator, always with init
                 else True
             )
 
-            if dataclass_init:
-                return ValueSet([DataclassWrapper(c)])
-            else:
-                return ValueSet([c])
+            return ValueSet(
+                [
+                    DataclassWrapper(
+                        c,
+                        dataclass_init,
+                        is_dataclass_transform=value.name.string_name
+                        == "dataclass_transform",
+                    )
+                ]
+            )
+
         else:
             # Decorator customization
             return ValueSet(

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup(name='jedi',
               'colorama',
               'Django',
               'attrs',
+              'typing_extensions',
           ],
           'qa': [
               # latest version supporting Python 3.6

--- a/test/test_inference/test_signature.py
+++ b/test/test_inference/test_signature.py
@@ -356,6 +356,80 @@ def test_dataclass_signature(Script, skip_pre_python37, start, start_params):
 
 @pytest.mark.parametrize(
     'start, start_params', [
+        ['@dataclass_transform\nclass X:', []],
+        ['@dataclass_transform(eq=True)\nclass X:', []],
+        [dedent('''
+         class Y():
+             y: int
+         @dataclass_transform
+         class X(Y):'''), []],
+        [dedent('''
+         @dataclass_transform
+         class Y():
+             y: int
+             z = 5
+         @dataclass_transform
+         class X(Y):'''), ['y']],
+    ]
+)
+def test_extensions_dataclass_transform_signature(Script, skip_pre_python37, start, start_params):
+    code = dedent('''
+            name: str
+            foo = 3
+            price: float
+            quantity: int = 0.0
+
+        X(''')
+
+    code = 'from typing_extensions import dataclass_transform\n' + start + code
+
+    sig, = Script(code).get_signatures()
+    assert [p.name for p in sig.params] == start_params + ['name', 'price', 'quantity']
+    quantity, = sig.params[-1].infer()
+    assert quantity.name == 'int'
+    price, = sig.params[-2].infer()
+    assert price.name == 'float'
+
+
+@pytest.mark.parametrize(
+    'start, start_params', [
+        ['@dataclass_transform\nclass X:', []],
+        ['@dataclass_transform(eq=True)\nclass X:', []],
+        [dedent('''
+         class Y():
+             y: int
+         @dataclass_transform
+         class X(Y):'''), []],
+        [dedent('''
+         @dataclass_transform
+         class Y():
+             y: int
+             z = 5
+         @dataclass_transform
+         class X(Y):'''), ['y']],
+    ]
+)
+def test_dataclass_transform_signature(Script, skip_pre_python311, start, start_params):
+    code = dedent('''
+            name: str
+            foo = 3
+            price: float
+            quantity: int = 0.0
+
+        X(''')
+
+    code = 'from typing import dataclass_transform\n' + start + code
+
+    sig, = Script(code).get_signatures()
+    assert [p.name for p in sig.params] == start_params + ['name', 'price', 'quantity']
+    quantity, = sig.params[-1].infer()
+    assert quantity.name == 'int'
+    price, = sig.params[-2].infer()
+    assert price.name == 'float'
+
+
+@pytest.mark.parametrize(
+    'start, start_params', [
         ['@define\nclass X:', []],
         ['@frozen\nclass X:', []],
         ['@define(eq=True)\nclass X:', []],

--- a/test/test_inference/test_signature.py
+++ b/test/test_inference/test_signature.py
@@ -432,7 +432,7 @@ dataclass_transform_cases = [
     # Base Class
     ['@dataclass_transform\nclass X:', [], False],
     # Base Class with params
-    ['@dataclass_transform(eq=True)\nclass X:', [], False],
+    ['@dataclass_transform(eq_default=True)\nclass X:', [], False],
     # Subclass
     [dedent('''
         class Y():
@@ -443,6 +443,13 @@ dataclass_transform_cases = [
     # Class based
     [dedent('''
         @dataclass_transform
+        class Y():
+            y: int
+            z = 5
+        class X(Y):'''), [], True],
+    # Class based with params
+    [dedent('''
+        @dataclass_transform(eq_default=True)
         class Y():
             y: int
             z = 5
@@ -465,19 +472,6 @@ dataclass_transform_cases = [
             p = 5
         class X(ModelBase):'''), [], True],
     # 3/ Init tweaks
-    # init=False
-    [dedent('''
-        @dataclass_transform(init=False)
-        class Y():
-            y: int
-            z = 5
-        class X(Y):'''), [], False],
-    [dedent('''
-        @dataclass_transform(eq=True, init=False)
-        class Y():
-            y: int
-            z = 5
-        class X(Y):'''), [], False],
     # custom init
     [dedent('''
     @dataclass_transform()
@@ -495,10 +489,9 @@ ids = [
     "transformer_with_params",
     "subclass_transformer",
     "base_transformed",
+    "base_transformed_with_params",
     "decorator_transformed",
     "metaclass_transformed",
-    "init_false",
-    "init_false_multiple",
     "custom_init",
 ]
 

--- a/test/test_inference/test_signature.py
+++ b/test/test_inference/test_signature.py
@@ -393,14 +393,15 @@ def test_dataclass_signature(
             name: str
             foo = 3
             blob: ClassVar[str]
-            price: float
+            price: Final[float]
             quantity: int = 0.0
 
         X("""
     )
 
     code = (
-        "from dataclasses import dataclass\nfrom typing import ClassVar\n"
+        "from dataclasses import dataclass\n"
+        + "from typing import ClassVar, Final\n"
         + start
         + code
     )

--- a/test/test_inference/test_signature.py
+++ b/test/test_inference/test_signature.py
@@ -392,13 +392,18 @@ def test_dataclass_signature(
         """
             name: str
             foo = 3
+            blob: ClassVar[str]
             price: float
             quantity: int = 0.0
 
         X("""
     )
 
-    code = 'from dataclasses import dataclass\n' + start + code
+    code = (
+        "from dataclasses import dataclass\nfrom typing import ClassVar\n"
+        + start
+        + code
+    )
 
     sig, = Script(code).get_signatures()
     expected_params = (

--- a/test/test_inference/test_signature.py
+++ b/test/test_inference/test_signature.py
@@ -771,6 +771,23 @@ def test_extensions_dataclass_transform_signature(
         assert price.name == price_type_infer
 
 
+def test_dataclass_transform_complete(Script):
+    script = Script('''\
+        @dataclass_transform
+        class Y():
+            y: int
+            z = 5
+
+        class X(Y):
+            name: str
+            foo = 3
+
+        def f(x: X):
+            x.na''')
+    completion, = script.complete()
+    assert completion.description == 'name: str'
+
+
 @pytest.mark.parametrize(
     "start, start_params, include_params", dataclass_transform_cases, ids=ids
 )

--- a/test/test_inference/test_signature.py
+++ b/test/test_inference/test_signature.py
@@ -522,13 +522,19 @@ def test_extensions_dataclass_transform_signature(
         """
             name: str
             foo = 3
-            price: float
+            blob: ClassVar[str]
+            price: Final[float]
             quantity: int = 0.0
 
         X("""
     )
 
-    code = "from typing_extensions import dataclass_transform\n" + start + code
+    code = (
+        "from typing_extensions import dataclass_transform\n"
+        + "from typing import ClassVar, Final\n"
+        + start
+        + code
+    )
 
     (sig,) = Script(code).get_signatures()
     expected_params = (
@@ -542,7 +548,7 @@ def test_extensions_dataclass_transform_signature(
         quantity, = sig.params[-1].infer()
         assert quantity.name == 'int'
         price, = sig.params[-2].infer()
-        assert price.name == 'float'
+        assert price.name == 'object'
 
 
 @pytest.mark.parametrize(
@@ -554,12 +560,18 @@ def test_dataclass_transform_signature(
     code = dedent('''
             name: str
             foo = 3
-            price: float
+            blob: ClassVar[str]
+            price: Final[float]
             quantity: int = 0.0
 
         X(''')
 
-    code = 'from typing import dataclass_transform\n' + start + code
+    code = (
+        "from typing import dataclass_transform\n"
+        + "from typing import ClassVar, Final\n"
+        + start
+        + code
+    )
 
     sig, = Script(code).get_signatures()
     expected_params = (
@@ -573,7 +585,7 @@ def test_dataclass_transform_signature(
         quantity, = sig.params[-1].infer()
         assert quantity.name == 'int'
         price, = sig.params[-2].infer()
-        assert price.name == 'float'
+        assert price.name == 'object'
 
 
 @pytest.mark.parametrize(

--- a/test/test_inference/test_signature.py
+++ b/test/test_inference/test_signature.py
@@ -390,14 +390,22 @@ def test_wraps_signature(Script, code, signature):
     ],
 )
 def test_dataclass_signature(
-    Script, skip_pre_python37, start, start_params, include_params
+    Script, skip_pre_python37, start, start_params, include_params, environment
 ):
+    if environment.version_info < (3, 8):
+        # Final is not yet supported
+        price_type = "float"
+        price_type_infer = "float"
+    else:
+        price_type = "Final[float]"
+        price_type_infer = "object"
+
     code = dedent(
-        """
+        f"""
             name: str
             foo = 3
             blob: ClassVar[str]
-            price: Final[float]
+            price: {price_type}
             quantity: int = 0.0
 
         X("""
@@ -422,7 +430,7 @@ def test_dataclass_signature(
         quantity, = sig.params[-1].infer()
         assert quantity.name == 'int'
         price, = sig.params[-2].infer()
-        assert price.name == 'object'
+        assert price.name == price_type_infer
 
 
 dataclass_transform_cases = [

--- a/test/test_inference/test_signature.py
+++ b/test/test_inference/test_signature.py
@@ -350,11 +350,17 @@ def test_wraps_signature(Script, code, signature):
         [
             dedent(
                 """
-            @dataclass_transform(init=False)
-            class Y():
-                y: int
-                z = 5
-            class X(Y):"""
+            @dataclass(init=False)
+            class X:"""
+            ),
+            [],
+            False,
+        ],
+        [
+            dedent(
+                """
+            @dataclass(eq=True, init=False)
+            class X:"""
             ),
             [],
             False,
@@ -363,11 +369,8 @@ def test_wraps_signature(Script, code, signature):
         [
             dedent(
                 """
-        @dataclass_transform()
-        class Y():
-            y: int
-            z = 5
-        class X(Y):
+        @dataclass()
+        class X:
             def __init__(self, toto: str):
                 pass
             """
@@ -382,6 +385,7 @@ def test_wraps_signature(Script, code, signature):
         "subclass_transformed",
         "both_transformed",
         "init_false",
+        "init_false_multiple",
         "custom_init",
     ],
 )
@@ -418,7 +422,7 @@ def test_dataclass_signature(
         quantity, = sig.params[-1].infer()
         assert quantity.name == 'int'
         price, = sig.params[-2].infer()
-        assert price.name == 'float'
+        assert price.name == 'object'
 
 
 dataclass_transform_cases = [

--- a/test/test_inference/test_signature.py
+++ b/test/test_inference/test_signature.py
@@ -482,6 +482,30 @@ dataclass_transform_cases = [
         def __init__(self, toto: str):
             pass
         '''), ["toto"], False],
+    # Class based init=false
+    [dedent('''
+        @dataclass_transform
+        class Y():
+            y: int
+            z = 5
+        class X(Y, init=False):'''), [], False],
+    # Decorator based init=false
+    [dedent('''
+        @dataclass_transform
+        def create_model():
+            pass
+        @create_model(init=False)
+        class X:'''), [], False],
+    # Metaclass based init=false
+    [dedent('''
+        @dataclass_transform
+        class ModelMeta():
+            y: int
+            z = 5
+        class ModelBase(metaclass=ModelMeta):
+            t: int
+            p = 5
+        class X(ModelBase, init=False):'''), [], False],
 ]
 
 ids = [
@@ -493,6 +517,9 @@ ids = [
     "decorator_transformed",
     "metaclass_transformed",
     "custom_init",
+    "base_transformed_init_false",
+    "decorator_transformed_init_false",
+    "metaclass_transformed_init_false",
 ]
 
 

--- a/test/test_inference/test_signature.py
+++ b/test/test_inference/test_signature.py
@@ -354,23 +354,56 @@ def test_dataclass_signature(Script, skip_pre_python37, start, start_params):
     assert price.name == 'float'
 
 
+dataclass_transform_cases = [
+    # Direct
+    ['@dataclass_transform\nclass X:', []],
+    # With params
+    ['@dataclass_transform(eq=True)\nclass X:', []],
+    # Subclass
+    [dedent('''
+        class Y():
+            y: int
+        @dataclass_transform
+        class X(Y):'''), []],
+    # Both classes
+    [dedent('''
+        @dataclass_transform
+        class Y():
+            y: int
+            z = 5
+        @dataclass_transform
+        class X(Y):'''), ['y']],
+    # Base class
+    [dedent('''
+        @dataclass_transform
+        class Y():
+            y: int
+            z = 5
+        class X(Y):'''), []],
+    # Alternative decorator
+    [dedent('''
+        @dataclass_transform
+        def create_model(cls):
+            return cls
+        @create_model
+        class X:'''), []],
+    # Metaclass
+    [dedent('''
+        @dataclass_transform
+        class ModelMeta():
+            y: int
+            z = 5
+        class ModelBase(metaclass=ModelMeta):
+            t: int
+            p = 5
+        class X(ModelBase):'''), []],
+]
+
+ids = ["direct", "with_params", "sub", "both", "base", "alternative_decorator", "metaclass"]
+
+
 @pytest.mark.parametrize(
-    'start, start_params', [
-        ['@dataclass_transform\nclass X:', []],
-        ['@dataclass_transform(eq=True)\nclass X:', []],
-        [dedent('''
-         class Y():
-             y: int
-         @dataclass_transform
-         class X(Y):'''), []],
-        [dedent('''
-         @dataclass_transform
-         class Y():
-             y: int
-             z = 5
-         @dataclass_transform
-         class X(Y):'''), ['y']],
-    ]
+    'start, start_params', dataclass_transform_cases, ids=ids
 )
 def test_extensions_dataclass_transform_signature(Script, skip_pre_python37, start, start_params):
     code = dedent('''
@@ -392,22 +425,7 @@ def test_extensions_dataclass_transform_signature(Script, skip_pre_python37, sta
 
 
 @pytest.mark.parametrize(
-    'start, start_params', [
-        ['@dataclass_transform\nclass X:', []],
-        ['@dataclass_transform(eq=True)\nclass X:', []],
-        [dedent('''
-         class Y():
-             y: int
-         @dataclass_transform
-         class X(Y):'''), []],
-        [dedent('''
-         @dataclass_transform
-         class Y():
-             y: int
-             z = 5
-         @dataclass_transform
-         class X(Y):'''), ['y']],
-    ]
+    'start, start_params', dataclass_transform_cases, ids=ids
 )
 def test_dataclass_transform_signature(Script, skip_pre_python311, start, start_params):
     code = dedent('''

--- a/test/test_inference/test_signature.py
+++ b/test/test_inference/test_signature.py
@@ -450,8 +450,8 @@ dataclass_transform_cases = [
     # Decorator based
     [dedent('''
         @dataclass_transform
-        def create_model(cls):
-            return cls
+        def create_model():
+            pass
         @create_model
         class X:'''), [], True],
     # Metaclass based

--- a/test/test_inference/test_signature.py
+++ b/test/test_inference/test_signature.py
@@ -346,6 +346,20 @@ def test_wraps_signature(Script, code, signature):
             ["y"],
             True,
         ],
+        [
+            dedent(
+                """
+         @dataclass
+         class Y():
+             y: int
+         class Z(Y): # Not included
+             z = 5
+         @dataclass
+         class X(Z):"""
+            ),
+            ["y"],
+            True,
+        ],
         # init=False
         [
             dedent(
@@ -384,6 +398,7 @@ def test_wraps_signature(Script, code, signature):
         "transformed_with_params",
         "subclass_transformed",
         "both_transformed",
+        "intermediate_not_transformed",
         "init_false",
         "init_false_multiple",
         "custom_init",
@@ -469,6 +484,34 @@ dataclass_transform_cases = [
             pass
         @create_model
         class X:'''), [], True],
+    [dedent('''
+        @dataclass_transform
+        def create_model():
+            pass
+        class Y:
+            y: int
+        @create_model
+        class X(Y):'''), [], True],
+    [dedent('''
+        @dataclass_transform
+        def create_model():
+            pass
+        @create_model
+        class Y:
+            y: int
+        @create_model
+        class X(Y):'''), ["y"], True],
+    [dedent('''
+        @dataclass_transform
+        def create_model():
+            pass
+        @create_model
+        class Y:
+            y: int
+        class Z(Y):
+            z: int
+        @create_model
+        class X(Z):'''), ["y"], True],
     # Metaclass based
     [dedent('''
         @dataclass_transform
@@ -547,7 +590,10 @@ ids = [
     "subclass_transformer",
     "base_transformed",
     "base_transformed_with_params",
-    "decorator_transformed",
+    "decorator_transformed_direct",
+    "decorator_transformed_subclass",
+    "decorator_transformed_both",
+    "decorator_transformed_intermediate_not",
     "metaclass_transformed",
     "custom_init",
     "base_transformed_init_false",

--- a/test/test_inference/test_signature.py
+++ b/test/test_inference/test_signature.py
@@ -439,14 +439,6 @@ dataclass_transform_cases = [
             y: int
         @dataclass_transform
         class X(Y):'''), [], False],
-    # Both classes
-    [dedent('''
-        @dataclass_transform
-        class Y():
-            y: int
-            z = 5
-        @dataclass_transform
-        class X(Y):'''), [], False],
     # 2/ Declare dataclass transformed
     # Class based
     [dedent('''
@@ -502,7 +494,6 @@ ids = [
     "direct_transformer",
     "transformer_with_params",
     "subclass_transformer",
-    "both_transformer",
     "base_transformed",
     "decorator_transformed",
     "metaclass_transformed",

--- a/test/test_inference/test_signature.py
+++ b/test/test_inference/test_signature.py
@@ -534,6 +534,40 @@ dataclass_transform_cases = [
         '''), ["toto"], False],
     # 4/ init=false
     # Class based
+    # WARNING: Unsupported
+    # [dedent('''
+    #     @dataclass_transform
+    #     class Y():
+    #         y: int
+    #         z = 5
+    #         def __init_subclass__(
+    #             cls,
+    #             *,
+    #             init: bool = False,
+    #         )
+    #     class X(Y):'''), [], False],
+    [dedent('''
+        @dataclass_transform
+        class Y():
+            y: int
+            z = 5
+            def __init_subclass__(
+                cls,
+                *,
+                init: bool = False,
+            )
+        class X(Y, init=True):'''), [], True],
+    [dedent('''
+        @dataclass_transform
+        class Y():
+            y: int
+            z = 5
+            def __init_subclass__(
+                cls,
+                *,
+                init: bool = False,
+            )
+        class X(Y, init=False):'''), [], False],
     [dedent('''
         @dataclass_transform
         class Y():
@@ -543,11 +577,83 @@ dataclass_transform_cases = [
     # Decorator based
     [dedent('''
         @dataclass_transform
+        def create_model(init=False):
+            pass
+        @create_model()
+        class X:'''), [], False],
+    [dedent('''
+        @dataclass_transform
+        def create_model(init=False):
+            pass
+        @create_model(init=True)
+        class X:'''), [], True],
+    [dedent('''
+        @dataclass_transform
+        def create_model(init=False):
+            pass
+        @create_model(init=False)
+        class X:'''), [], False],
+    [dedent('''
+        @dataclass_transform
         def create_model():
             pass
         @create_model(init=False)
         class X:'''), [], False],
     # Metaclass based
+    [dedent('''
+        @dataclass_transform
+        class ModelMeta():
+            y: int
+            z = 5
+            def __new__(
+                cls,
+                name,
+                bases,
+                namespace,
+                *,
+                init: bool = False,
+            ):
+                ...
+        class ModelBase(metaclass=ModelMeta):
+            t: int
+            p = 5
+        class X(ModelBase):'''), [], False],
+    [dedent('''
+        @dataclass_transform
+        class ModelMeta():
+            y: int
+            z = 5
+            def __new__(
+                cls,
+                name,
+                bases,
+                namespace,
+                *,
+                init: bool = False,
+            ):
+                ...
+        class ModelBase(metaclass=ModelMeta):
+            t: int
+            p = 5
+        class X(ModelBase, init=True):'''), [], True],
+    [dedent('''
+        @dataclass_transform
+        class ModelMeta():
+            y: int
+            z = 5
+            def __new__(
+                cls,
+                name,
+                bases,
+                namespace,
+                *,
+                init: bool = False,
+            ):
+                ...
+        class ModelBase(metaclass=ModelMeta):
+            t: int
+            p = 5
+        class X(ModelBase, init=False):'''), [], False],
     [dedent('''
         @dataclass_transform
         class ModelMeta():
@@ -596,9 +702,18 @@ ids = [
     "decorator_transformed_intermediate_not",
     "metaclass_transformed",
     "custom_init",
-    "base_transformed_init_false",
-    "decorator_transformed_init_false",
-    "metaclass_transformed_init_false",
+    # "base_transformed_init_false_dataclass_init_default",
+    "base_transformed_init_false_dataclass_init_true",
+    "base_transformed_init_false_dataclass_init_false",
+    "base_transformed_init_default_dataclass_init_false",
+    "decorator_transformed_init_false_dataclass_init_default",
+    "decorator_transformed_init_false_dataclass_init_true",
+    "decorator_transformed_init_false_dataclass_init_false",
+    "decorator_transformed_init_default_dataclass_init_false",
+    "metaclass_transformed_init_false_dataclass_init_default",
+    "metaclass_transformed_init_false_dataclass_init_true",
+    "metaclass_transformed_init_false_dataclass_init_false",
+    "metaclass_transformed_init_default_dataclass_init_false",
     "base_transformed_other_parameters",
     "decorator_transformed_other_parameters",
     "metaclass_transformed_other_parameters",

--- a/test/test_inference/test_signature.py
+++ b/test/test_inference/test_signature.py
@@ -509,6 +509,10 @@ ids = [
 def test_extensions_dataclass_transform_signature(
     Script, skip_pre_python37, start, start_params, include_params
 ):
+    has_typing_ext = bool(Script('import typing_extensions').infer())
+    if not has_typing_ext:
+        raise pytest.skip("typing_extensions needed in target environment to run this test")
+
     code = dedent(
         """
             name: str
@@ -596,7 +600,8 @@ def test_dataclass_transform_signature(
              z = 5
          @define
          class X(Y):'''), ['y']],
-    ]
+    ],
+    ids=["define", "frozen", "define_customized", "define_subclass", "define_both"]
 )
 def test_attrs_signature(Script, skip_pre_python37, start, start_params):
     has_attrs = bool(Script('import attrs').infer())

--- a/test/test_inference/test_signature.py
+++ b/test/test_inference/test_signature.py
@@ -471,8 +471,7 @@ dataclass_transform_cases = [
             t: int
             p = 5
         class X(ModelBase):'''), [], True],
-    # 3/ Init tweaks
-    # custom init
+    # 3/ Init custom init
     [dedent('''
     @dataclass_transform()
     class Y():
@@ -482,21 +481,22 @@ dataclass_transform_cases = [
         def __init__(self, toto: str):
             pass
         '''), ["toto"], False],
-    # Class based init=false
+    # 4/ init=false
+    # Class based
     [dedent('''
         @dataclass_transform
         class Y():
             y: int
             z = 5
         class X(Y, init=False):'''), [], False],
-    # Decorator based init=false
+    # Decorator based
     [dedent('''
         @dataclass_transform
         def create_model():
             pass
         @create_model(init=False)
         class X:'''), [], False],
-    # Metaclass based init=false
+    # Metaclass based
     [dedent('''
         @dataclass_transform
         class ModelMeta():
@@ -506,6 +506,31 @@ dataclass_transform_cases = [
             t: int
             p = 5
         class X(ModelBase, init=False):'''), [], False],
+    # 4/ Other parameters
+    # Class based
+    [dedent('''
+        @dataclass_transform
+        class Y():
+            y: int
+            z = 5
+        class X(Y, eq=True):'''), [], True],
+    # Decorator based
+    [dedent('''
+        @dataclass_transform
+        def create_model():
+            pass
+        @create_model(eq=True)
+        class X:'''), [], True],
+    # Metaclass based
+    [dedent('''
+        @dataclass_transform
+        class ModelMeta():
+            y: int
+            z = 5
+        class ModelBase(metaclass=ModelMeta):
+            t: int
+            p = 5
+        class X(ModelBase, eq=True):'''), [], True],
 ]
 
 ids = [
@@ -520,6 +545,9 @@ ids = [
     "base_transformed_init_false",
     "decorator_transformed_init_false",
     "metaclass_transformed_init_false",
+    "base_transformed_other_parameters",
+    "decorator_transformed_other_parameters",
+    "metaclass_transformed_other_parameters",
 ]
 
 


### PR DESCRIPTION
# Goal

Support dataclass transform as specified: https://typing.readthedocs.io/en/latest/spec/dataclasses.html#dataclass-transform

# Motivation

To have signature completions when using libraries like `Pydantic` or `SQLalchemy`.

# Features

- [X] Final attributes (already supported, just tested)
- [X] Support ClassVar (excluded from init)
- [X] dataclass_transform base class
- [X] dataclass_transform decorator
- [X] dataclass_transform metaclass
- [x] init=False. The dataclass_transform decorator, metaclass or base class are always assumed to default to init=True. However if it is setting `init=False`, the parameters are by default ignored. If the defined dataclass-semantics is overriding the `init`, it takes precedence.

Not covered:
- `(dataclasses.Field, dataclasses.field) init=False` / `dataclass_transform field_specifiers init=False`. Those fields are always present. It may also show the wrong type/default value but as before this MR.
- Base Model with custom default is not feasible as `__init_subclass__` signature is hardcoded in the jedi third_party typeshed. So `init` can not be introspected.

# Technical details

1. Python Support

```python
# 3.11+
from typing import dataclass_transform
# <3.11
from typing_extensions import dataclass_transform
```

2. The decorator usage is very similar to the `dataclasses.dataclass`

3. With a difference though:

> If dataclass_transform is applied to a class, dataclass-like semantics will be assumed for any class that directly or indirectly derives from the decorated class or uses the decorated class as a metaclass. Attributes on the decorated class and its base classes are not considered to be fields.