### PR TITLE
Explicit sphinx config path

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,6 +10,9 @@ python:
 submodules:
   include: all
 
+sphinx:
+  configuration: docs/conf.py
+
 build:
   os: ubuntu-22.04
   tools:


### PR DESCRIPTION
This is now required by ReadTheDocs; see
https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/