### PR TITLE
limit columns to line_length

### DIFF
--- a/jedi/api/helpers.py
+++ b/jedi/api/helpers.py
@@ -479,7 +479,7 @@ def validate_line_column(func):
         elif line_string.endswith('\n'):
             line_len -= 1
 
-        column = line_len if column is None else column
+        column = min(line_len, line_len if column is None else column)
         if not (0 <= column <= line_len):
             raise ValueError('`column` parameter (%d) is not in a valid range '
                              '(0-%d) for line %d (%r).' % (


### PR DESCRIPTION
(neo)vim provides a mode "virtualedit=all" where the cursor can be placed behind the last character of the line. Limit the column to line_lenght prevents raising a ValueError