### PR TITLE
Add Python 3.14 into CI configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04, windows-2022]
-        python-version: ["3.13", "3.12", "3.11", "3.10", "3.9", "3.8"]
-        environment: ['3.8', '3.13', '3.12', '3.11', '3.10', '3.9', 'interpreter']
+        python-version: ["3.14", "3.13", "3.12", "3.11", "3.10", "3.9", "3.8"]
+        environment: ['3.8', '3.14', '3.13', '3.12', '3.11', '3.10', '3.9', 'interpreter']
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Related to #2064 

This adds Python 3.14 to CI without adding it to the supported versions yet.