### PR TITLE
Fix unhandled '*' operator in infer_node

### DIFF
--- a/test/completion/arrays.py
+++ b/test/completion/arrays.py
@@ -527,3 +527,11 @@ lc = [x for a, *x in [(1, '', 1.0)]]
 lc[0][0]
 #?
 lc[0][1]
+
+
+xy = (1,)
+x, y = *xy, None
+
+# whatever it is should not crash
+#?
+x

--- a/test/completion/wtf.py
+++ b/test/completion/wtf.py
@@ -1,6 +1,0 @@
-xy = (1,)
-x, y = *xy, None
-
-# whatever it is should not crash
-#?
-x


### PR DESCRIPTION
The PR fixes a crash shown as follows.

## reproduction
```python
import jedi
MAIN_PY_CONTENT="""\
xy = (1,)
x, y = *xy, None

#?
x
"""
script = jedi.Script(code=MAIN_PY_CONTENT) 
script.infer(5, 1)
```
The above is valid python code, and jedi should not crash.

## brief walkthrough
```
1 xy = (1,)
2 x, y = *xy, None
3
4 #?
5 x
```

1. tries to infer `x` at line 5
2. leads to inferring `x = *xy` at line 2
3. enters `_infer_node(context,element)` with element is `*xy` with type `star_expr`.
4. none of the if clauses catches `star_expr`, so it goes to the final `    else:        return infer_or_test(context, element)`
5. `infer_or_test` assumes the element is like `n1 OP n2 OP n3` (link to the [code](https://github.com/davidhalter/jedi/blob/master/jedi/inference/syntax_tree.py#L459) )
6. it tries to infer `n1`, but the element is `*xy`, so it ends up inferring the star operator
7. we don't do that . the only operator we infer is the Ellipsis .

The fix is simple, just let star_expr infer to `NO_VALUES`  .
I'm quite new to jedi, so I might miss better fixes. If so I'm happy to revise.

## crash logs
```
Traceback (most recent call last):
  File "/home/den/Programs/test/testjedi2/main3.py", line 10, in <module>
    script.infer(5, 1)
  File "/home/den/anaconda3/envs/abc_jedi/lib/python3.11/site-packages/jedi/api/helpers.py", line 487, in wrapper
    return func(self, line, column, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/den/anaconda3/envs/abc_jedi/lib/python3.11/site-packages/jedi/api/__init__.py", line 249, in infer
    values = helpers.infer(self._inference_state, context, leaf)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/den/anaconda3/envs/abc_jedi/lib/python3.11/site-packages/jedi/api/helpers.py", line 167, in infer
    return inference_state.infer(context, leaf)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/den/anaconda3/envs/abc_jedi/lib/python3.11/site-packages/jedi/inference/__init__.py", line 181, in infer
    return helpers.infer_call_of_leaf(context, name)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/den/anaconda3/envs/abc_jedi/lib/python3.11/site-packages/jedi/inference/helpers.py", line 79, in infer_call_of_leaf
    return context.infer_node(leaf)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/den/anaconda3/envs/abc_jedi/lib/python3.11/site-packages/jedi/inference/context.py", line 224, in infer_node
    return infer_node(self, node)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/den/anaconda3/envs/abc_jedi/lib/python3.11/site-packages/jedi/inference/syntax_tree.py", line 157, in infer_node
    return _infer_node_if_inferred(context, element)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/den/anaconda3/envs/abc_jedi/lib/python3.11/site-packages/jedi/inference/syntax_tree.py", line 170, in _infer_node_if_inferred
    return _infer_node_cached(context, element)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/den/anaconda3/envs/abc_jedi/lib/python3.11/site-packages/jedi/inference/cache.py", line 44, in wrapper
    rv = function(obj, *args, **kwargs)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/den/anaconda3/envs/abc_jedi/lib/python3.11/site-packages/jedi/inference/syntax_tree.py", line 175, in _infer_node_cached
    return _infer_node(context, element)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/den/anaconda3/envs/abc_jedi/lib/python3.11/site-packages/jedi/debug.py", line 81, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/den/anaconda3/envs/abc_jedi/lib/python3.11/site-packages/jedi/inference/syntax_tree.py", line 83, in wrapper
    return func(context, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/den/anaconda3/envs/abc_jedi/lib/python3.11/site-packages/jedi/inference/syntax_tree.py", line 187, in _infer_node
    return infer_atom(context, element)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/den/anaconda3/envs/abc_jedi/lib/python3.11/site-packages/jedi/inference/syntax_tree.py", line 307, in infer_atom
    return context.py__getattribute__(atom, position=position)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/den/anaconda3/envs/abc_jedi/lib/python3.11/site-packages/jedi/inference/context.py", line 77, in py__getattribute__
    values = ValueSet.from_sets(name.infer() for name in names)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/den/anaconda3/envs/abc_jedi/lib/python3.11/site-packages/jedi/inference/base_value.py", line 430, in from_sets
    for set_ in sets:
  File "/home/den/anaconda3/envs/abc_jedi/lib/python3.11/site-packages/jedi/inference/context.py", line 77, in <genexpr>
    values = ValueSet.from_sets(name.infer() for name in names)
                                ^^^^^^^^^^^^
  File "/home/den/anaconda3/envs/abc_jedi/lib/python3.11/site-packages/jedi/inference/names.py", line 281, in infer
    return tree_name_to_values(
           ^^^^^^^^^^^^^^^^^^^^
  File "/home/den/anaconda3/envs/abc_jedi/lib/python3.11/site-packages/jedi/plugins/__init__.py", line 21, in wrapper
    return built_functions[public_name](*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/den/anaconda3/envs/abc_jedi/lib/python3.11/site-packages/jedi/plugins/stdlib.py", line 878, in wrapper
    return func(inference_state, context, tree_name)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/den/anaconda3/envs/abc_jedi/lib/python3.11/site-packages/jedi/plugins/django.py", line 177, in wrapper
    result = func(inference_state, context, tree_name)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/den/anaconda3/envs/abc_jedi/lib/python3.11/site-packages/jedi/inference/syntax_tree.py", line 760, in tree_name_to_values
    types = infer_expr_stmt(context, node, tree_name)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/den/anaconda3/envs/abc_jedi/lib/python3.11/site-packages/jedi/inference/syntax_tree.py", line 83, in wrapper
    return func(context, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/den/anaconda3/envs/abc_jedi/lib/python3.11/site-packages/jedi/inference/syntax_tree.py", line 379, in infer_expr_stmt
    return _infer_expr_stmt(context, stmt, seek_name)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/den/anaconda3/envs/abc_jedi/lib/python3.11/site-packages/jedi/debug.py", line 81, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/den/anaconda3/envs/abc_jedi/lib/python3.11/site-packages/jedi/inference/syntax_tree.py", line 416, in _infer_expr_stmt
    value_set = check_tuple_assignments(n, value_set)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/den/anaconda3/envs/abc_jedi/lib/python3.11/site-packages/jedi/inference/syntax_tree.py", line 868, in check_tuple_assignments
    value_set = lazy_value.infer()
                ^^^^^^^^^^^^^^^^^^
  File "/home/den/anaconda3/envs/abc_jedi/lib/python3.11/site-packages/jedi/inference/lazy_value.py", line 48, in infer
    return self.context.infer_node(self.data)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/den/anaconda3/envs/abc_jedi/lib/python3.11/site-packages/jedi/inference/context.py", line 224, in infer_node
    return infer_node(self, node)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/den/anaconda3/envs/abc_jedi/lib/python3.11/site-packages/jedi/inference/syntax_tree.py", line 157, in infer_node
    return _infer_node_if_inferred(context, element)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/den/anaconda3/envs/abc_jedi/lib/python3.11/site-packages/jedi/inference/syntax_tree.py", line 170, in _infer_node_if_inferred
    return _infer_node_cached(context, element)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/den/anaconda3/envs/abc_jedi/lib/python3.11/site-packages/jedi/inference/cache.py", line 44, in wrapper
    rv = function(obj, *args, **kwargs)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/den/anaconda3/envs/abc_jedi/lib/python3.11/site-packages/jedi/inference/syntax_tree.py", line 175, in _infer_node_cached
    return _infer_node(context, element)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/den/anaconda3/envs/abc_jedi/lib/python3.11/site-packages/jedi/debug.py", line 81, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/den/anaconda3/envs/abc_jedi/lib/python3.11/site-packages/jedi/inference/syntax_tree.py", line 83, in wrapper
    return func(context, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/den/anaconda3/envs/abc_jedi/lib/python3.11/site-packages/jedi/inference/syntax_tree.py", line 257, in _infer_node
    return infer_or_test(context, element)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/den/anaconda3/envs/abc_jedi/lib/python3.11/site-packages/jedi/inference/syntax_tree.py", line 463, in infer_or_test
    types = context.infer_node(next(iterator))
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/den/anaconda3/envs/abc_jedi/lib/python3.11/site-packages/jedi/inference/context.py", line 224, in infer_node
    return infer_node(self, node)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/den/anaconda3/envs/abc_jedi/lib/python3.11/site-packages/jedi/inference/syntax_tree.py", line 157, in infer_node
    return _infer_node_if_inferred(context, element)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/den/anaconda3/envs/abc_jedi/lib/python3.11/site-packages/jedi/inference/syntax_tree.py", line 170, in _infer_node_if_inferred
    return _infer_node_cached(context, element)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/den/anaconda3/envs/abc_jedi/lib/python3.11/site-packages/jedi/inference/cache.py", line 44, in wrapper
    rv = function(obj, *args, **kwargs)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/den/anaconda3/envs/abc_jedi/lib/python3.11/site-packages/jedi/inference/syntax_tree.py", line 175, in _infer_node_cached
    return _infer_node(context, element)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/den/anaconda3/envs/abc_jedi/lib/python3.11/site-packages/jedi/debug.py", line 81, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/den/anaconda3/envs/abc_jedi/lib/python3.11/site-packages/jedi/inference/syntax_tree.py", line 83, in wrapper
    return func(context, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/den/anaconda3/envs/abc_jedi/lib/python3.11/site-packages/jedi/inference/syntax_tree.py", line 232, in _infer_node
    raise AssertionError("unhandled operator %s in %s " % (repr(element.value), origin))
AssertionError: unhandled operator '*' in PythonNode(star_expr, [<Operator: *>, <Name: xy@2,8>])
```