### PR TITLE
Handle object with __file__ attribute having a None value (issue #2082)

### DIFF
--- a/jedi/inference/compiled/access.py
+++ b/jedi/inference/compiled/access.py
@@ -184,7 +184,7 @@ class DirectObjectAccess:
     def py__file__(self) -> Optional[Path]:
         try:
             return Path(self._obj.__file__)
-        except AttributeError:
+        except (AttributeError, TypeError):
             return None
 
     def py__doc__(self):


### PR DESCRIPTION
Handle TypeError from Path when __file__ attribute is None

Fixes  #2082