### PR TITLE
Fix AssertionError when completing after dot followed by newline

### DIFF
--- a/jedi/api/completion.py
+++ b/jedi/api/completion.py
@@ -290,7 +290,7 @@ class Completion:
                 )
             elif nonterminals[-1] in ('trailer', 'dotted_name') and nodes[-1] == '.':
                 dot = self._module_node.get_leaf_for_position(self._position)
-                if dot.type == "endmarker":
+                if dot.type in ("endmarker", "newline"):
                     # This is a bit of a weird edge case, maybe we can somehow
                     # generalize this.
                     dot = leaf.get_previous_leaf()

--- a/test/test_api/test_completion.py
+++ b/test/test_api/test_completion.py
@@ -461,3 +461,8 @@ def test_module_completions(Script, module):
 
 def test_whitespace_at_end_after_dot(Script):
     assert 'strip' in [c.name for c in Script('str. ').complete()]
+
+
+def test_whitespace_and_newline_after_dot(Script):
+    """Regression test for issue #1954."""
+    assert 'mro' in [c.name for c in Script('object. \n').complete(1, 8)]


### PR DESCRIPTION
## Summary

Completing `object. \n` at position (1, 8) crashes with `AssertionError: unhandled operator '.' in ...`.

```python
from jedi.api import Interpreter
Interpreter("object. \n", []).complete(1, 8)  # AssertionError
```

## Root cause

In `Completion._complete_python`, the code gets the leaf at the cursor position. When there's a space + newline after the dot, the leaf is a `newline` node, not the dot. The code handles `endmarker` as a special case but not `newline`, so the newline leaf falls through and the dot operator itself gets passed to `_complete_trailer` → `_infer_node`, which raises `AssertionError` on non-ellipsis operators.

## Fix

Added `"newline"` to the type check alongside `"endmarker"` on line 293 of `completion.py`:
```python
if dot.type in ("endmarker", "newline"):
```

## Test plan

- Added `test_whitespace_and_newline_after_dot` regression test
- All 143 existing completion tests pass
- Manually verified with `Interpreter`, `Script`, and various whitespace patterns

Fixes #1954

🤖 Generated with [Claude Code](https://claude.com/claude-code)