### PR TITLE
Fix typos in comments and docstrings

### DIFF
--- a/jedi/api/classes.py
+++ b/jedi/api/classes.py
@@ -831,7 +831,7 @@ class Signature(BaseSignature):
     def index(self):
         """
         Returns the param index of the current cursor position.
-        Returns None if the index cannot be found in the curent call.
+        Returns None if the index cannot be found in the current call.
 
         :rtype: int
         """

--- a/jedi/inference/__init__.py
+++ b/jedi/inference/__init__.py
@@ -125,7 +125,7 @@ class InferenceState:
         debug.dbg('execute result: %s in %s', value_set, value)
         return value_set
 
-    # mypy doesn't suppport decorated propeties (https://github.com/python/mypy/issues/1362)
+    # mypy doesn't support decorated properties (https://github.com/python/mypy/issues/1362)
     @property
     @inference_state_function_cache()
     def builtins_module(self):

--- a/jedi/inference/analysis.py
+++ b/jedi/inference/analysis.py
@@ -110,7 +110,7 @@ def _check_for_setattr(instance):
 
 def add_attribute_error(name_context, lookup_value, name):
     message = ('AttributeError: %s has no attribute %s.' % (lookup_value, name))
-    # Check for __getattr__/__getattribute__ existance and issue a warning
+    # Check for __getattr__/__getattribute__ existence and issue a warning
     # instead of an error, if that happens.
     typ = Error
     if lookup_value.is_instance() and not lookup_value.is_compiled():

--- a/jedi/inference/value/instance.py
+++ b/jedi/inference/value/instance.py
@@ -224,7 +224,7 @@ class _BaseTreeInstance(AbstractInstanceValue):
             elif isinstance(f, CompiledValueFilter):
                 yield CompiledInstanceClassFilter(self, f)
             else:
-                # Propably from the metaclass.
+                # Probably from the metaclass.
                 yield f
 
     @inference_state_method_cache()


### PR DESCRIPTION
Fixed minor typos found by codespell in source `.py` files:

- `curent` → `current` in `jedi/api/classes.py` (docstring)
- `suppport` → `support` and `propeties` → `properties` in `jedi/inference/__init__.py` (comment)
- `existance` → `existence` in `jedi/inference/analysis.py` (comment)
- `Propably` → `Probably` in `jedi/inference/value/instance.py` (comment)

All fixes are in comments or docstrings, not in code identifiers or strings used as keys.