### PR TITLE
fix: replace bare except with except Exception in utils.py

### DIFF
--- a/jedi/utils.py
+++ b/jedi/utils.py
@@ -90,7 +90,7 @@ def setup_readline(namespace_module=__main__, fuzzy=False):
                         text[:len(text) - c._like_name_length] + c.name_with_symbols
                         for c in completions
                     ]
-                except:
+                except Exception:
                     logging.error("REPL Completion error:\n" + traceback.format_exc())
                     raise
                 finally:


### PR DESCRIPTION
Bare `except:` clauses catch `BaseException`, which includes `KeyboardInterrupt`, `SystemExit`, and `GeneratorExit`. This means a Ctrl+C during REPL tab completion would be caught and logged as a "REPL Completion error" rather than propagating naturally.

Replace with `except Exception:` to catch only programmatic errors while allowing keyboard interrupts and system exits to propagate as expected.

**Change:**
```python
# Before
except:
    logging.error("REPL Completion error:\n" + traceback.format_exc())
    raise

# After
except Exception:
    logging.error("REPL Completion error:\n" + traceback.format_exc())
    raise
```