### PR TITLE
Fix `TypeError` when `get_line_code` called on literals

### DIFF
--- a/jedi/inference/compiled/value.py
+++ b/jedi/inference/compiled/value.py
@@ -415,6 +415,8 @@ class UnresolvableParamName(ParamNameInterface, AbstractNameDefinition):
 
 class CompiledValueName(ValueNameMixin, AbstractNameDefinition):
     def __init__(self, value, name):
+        if not hasattr(name, "start_pos"):
+            name.start_pos = value.atom.start_pos
         self.string_name = name
         self._value = value
         self.parent_context = value.parent_context

--- a/jedi/inference/compiled/value.py
+++ b/jedi/inference/compiled/value.py
@@ -415,8 +415,8 @@ class UnresolvableParamName(ParamNameInterface, AbstractNameDefinition):
 
 class CompiledValueName(ValueNameMixin, AbstractNameDefinition):
     def __init__(self, value, name):
-        if not hasattr(name, "start_pos"):
-            name.start_pos = value.atom.start_pos
+        if not hasattr(name, "start_pos") and hasattr(value, "atom"):
+            name.start_pos = getattr(value.atom, "start_pos", None)
         self.string_name = name
         self._value = value
         self.parent_context = value.parent_context


### PR DESCRIPTION
Calling this method on literals usually takes you to standard library code, tightly wrapping the underlying C. Not very useful most of the time, but a logical thing to ask for.

Jedi should have the ability.

The lack of it caused an error in emacs' anaconda-mode when attempting to inspect the name of a literal value.